### PR TITLE
Feat rebase mecanism

### DIFF
--- a/src/components/absorber/carbon_handler.cairo
+++ b/src/components/absorber/carbon_handler.cairo
@@ -133,9 +133,7 @@ mod AbsorberComponent {
             (carbon_g / CREDIT_CARBON_TON).try_into().expect('Absorber: Ton overflow')
         }
 
-        fn share_to_cc(
-            self: @ComponentState<TContractState>, share: u256, token_id: u256
-        ) -> u256 {
+        fn share_to_cc(self: @ComponentState<TContractState>, share: u256, token_id: u256) -> u256 {
             let cc_supply = self.get_vintage_supply(token_id).into();
             share * cc_supply / MULT_ACCURATE_SHARE
         }
@@ -308,9 +306,7 @@ mod AbsorberComponent {
             return found_vintage;
         }
 
-        fn get_vintage_supply(
-            self: @ComponentState<TContractState>, year: u256
-        ) -> u64 {
+        fn get_vintage_supply(self: @ComponentState<TContractState>, year: u256) -> u64 {
             let carbon_vintage: CarbonVintage = self.get_specific_carbon_vintage(year);
             carbon_vintage.cc_supply
         }

--- a/src/components/absorber/carbon_handler.cairo
+++ b/src/components/absorber/carbon_handler.cairo
@@ -138,6 +138,13 @@ mod AbsorberComponent {
             share * cc_supply / MULT_ACCURATE_SHARE
         }
 
+        fn cc_to_share(
+            self: @ComponentState<TContractState>, cc_value: u256, token_id: u256
+        ) -> u256 {
+            let cc_supply = self.get_vintage_supply(token_id).into();
+            (cc_value * MULT_ACCURATE_SHARE / cc_supply)
+        }
+
         fn is_setup(self: @ComponentState<TContractState>) -> bool {
             self.Absorber_project_carbon.read()
                 * self.Absorber_times.read().len().into()

--- a/src/components/absorber/carbon_handler.cairo
+++ b/src/components/absorber/carbon_handler.cairo
@@ -133,6 +133,13 @@ mod AbsorberComponent {
             (carbon_g / CREDIT_CARBON_TON).try_into().expect('Absorber: Ton overflow')
         }
 
+        fn share_to_cc(
+            self: @ComponentState<TContractState>, share: u256, token_id: u256
+        ) -> u256 {
+            let cc_supply = self.get_vintage_supply(token_id).into();
+            share * cc_supply / MULT_ACCURATE_SHARE
+        }
+
         fn is_setup(self: @ComponentState<TContractState>) -> bool {
             self.Absorber_project_carbon.read()
                 * self.Absorber_times.read().len().into()
@@ -276,7 +283,7 @@ mod AbsorberComponent {
         }
 
         fn get_specific_carbon_vintage(
-            self: @ComponentState<TContractState>, year: u64
+            self: @ComponentState<TContractState>, year: u256
         ) -> CarbonVintage {
             if year == 0 {
                 return Default::default();
@@ -299,6 +306,13 @@ mod AbsorberComponent {
             };
 
             return found_vintage;
+        }
+
+        fn get_vintage_supply(
+            self: @ComponentState<TContractState>, year: u256
+        ) -> u64 {
+            let carbon_vintage: CarbonVintage = self.get_specific_carbon_vintage(year);
+            carbon_vintage.cc_supply
         }
 
         fn get_cc_decimals(self: @ComponentState<TContractState>) -> u8 {

--- a/src/components/absorber/carbon_handler.cairo
+++ b/src/components/absorber/carbon_handler.cairo
@@ -227,6 +227,29 @@ mod AbsorberComponent {
             };
             cc_distribution.span()
         }
+
+        fn rebase_vintage(
+            ref self: ComponentState<TContractState>, token_id: u256, new_cc_supply: u64
+        ) {
+            let mut stored_vintages: List<CarbonVintage> = self.Absorber_vintage_cc.read();
+            let mut index = 0;
+            loop {
+                if index == stored_vintages.len() {
+                    break;
+                }
+
+                let stored_vintage: CarbonVintage = stored_vintages[index].clone();
+                if stored_vintage.cc_vintage == token_id.into() {
+                    let mut vintage = stored_vintages[index].clone();
+                    vintage.cc_supply = new_cc_supply;
+                    vintage.cc_rebase_status = true;
+                    let _ = stored_vintages.set(index, vintage);
+                    break;
+                }
+                index += 1;
+            };
+            self.Absorber_vintage_cc.write(stored_vintages);
+        }
     }
 
     #[embeddable_as(CarbonCreditsHandlerImpl)]

--- a/src/components/absorber/interface.cairo
+++ b/src/components/absorber/interface.cairo
@@ -30,6 +30,9 @@ trait IAbsorber<TContractState> {
     /// Returns the ton equivalent.
     fn get_ton_equivalent(self: @TContractState) -> u64;
 
+    ///  Returns the carbon credit balance of the given token id.
+    fn share_to_cc(self: @TContractState, share: u256, token_id: u256) -> u256;
+
     /// Returns true is the given project has been setup.
     fn is_setup(self: @TContractState) -> bool;
 
@@ -38,6 +41,9 @@ trait IAbsorber<TContractState> {
 
     /// Setup the project carbon for the given slot.
     fn set_project_carbon(ref self: TContractState, project_carbon: u256);
+
+    /// Adapt the cc_supply of a vintage, will impact holders balance.
+    fn rebase_vintage(ref self: TContractState, token_id: u256, new_cc_supply: u64);
 
     /// Compute number of Carbon Credit of each vintage for given value
     fn compute_carbon_vintage_distribution(self: @TContractState, share: u256) -> Span<u256>;
@@ -50,7 +56,9 @@ trait ICarbonCreditsHandler<TContractState> {
 
     fn get_years_vintage(self: @TContractState) -> Span<u256>;
 
-    fn get_specific_carbon_vintage(self: @TContractState, year: u64) -> CarbonVintage;
+    fn get_specific_carbon_vintage(self: @TContractState, year: u256) -> CarbonVintage;
+
+    fn get_vintage_supply(self: @TContractState, year: u256) -> u64;
 
     // Get number of decimal for total supply to have a carbon credit
     fn get_cc_decimals(self: @TContractState) -> u8;

--- a/src/components/absorber/interface.cairo
+++ b/src/components/absorber/interface.cairo
@@ -30,8 +30,11 @@ trait IAbsorber<TContractState> {
     /// Returns the ton equivalent.
     fn get_ton_equivalent(self: @TContractState) -> u64;
 
-    ///  Returns the carbon credit balance of the given token id.
+    ///  Convert a share of supply balance to a carbon credit balance.
     fn share_to_cc(self: @TContractState, share: u256, token_id: u256) -> u256;
+
+    // Convert a carbon credit balance to a share of supply balance.
+    fn cc_to_share(self: @TContractState, cc_value: u256, token_id: u256) -> u256;
 
     /// Returns true is the given project has been setup.
     fn is_setup(self: @TContractState) -> bool;

--- a/src/components/minter/mint.cairo
+++ b/src/components/minter/mint.cairo
@@ -249,12 +249,23 @@ mod MintComponent {
 
             // [Interaction] Comput the amount of cc for each vintage
             let project_address = self.Mint_carbonable_project_address.read();
-            let absorber = IAbsorberDispatcher { contract_address: project_address };
             let carbon_credits = ICarbonCreditsHandlerDispatcher {
                 contract_address: project_address
             };
-            let cc_distribution: Span<u256> = absorber.compute_carbon_vintage_distribution(share);
             let cc_years_vintages: Span<u256> = carbon_credits.get_years_vintage();
+            let n = cc_years_vintages.len();
+            // Initially, share is the same for all the vintages
+
+            let mut cc_shares: Array<u256> = ArrayTrait::<u256>::new();
+            let mut index = 0;
+            loop {
+                if index == n {
+                    break;
+                }
+                cc_shares.append(share);
+                index += 1;
+            };
+            let cc_shares = cc_shares.span();
 
             // [Interaction] Pay
             let token_address = self.Mint_payment_token_address.read();
@@ -271,7 +282,7 @@ mod MintComponent {
             // [Interaction] Mint
             // Implement Span<u256> to return the list of cc_vintage (token_id & year)
             let project = IProjectDispatcher { contract_address: project_address };
-            project.batch_mint(caller_address, cc_years_vintages, cc_distribution);
+            project.batch_mint(caller_address, cc_years_vintages, cc_shares);
 
             // [Event] Emit event
             let current_time = get_block_timestamp();
@@ -281,7 +292,7 @@ mod MintComponent {
                         Buy {
                             address: caller_address,
                             cc_years_vintages: cc_years_vintages,
-                            cc_distributed: cc_distribution
+                            cc_distributed: cc_shares
                         }
                     )
                 );
@@ -295,8 +306,8 @@ mod MintComponent {
                 self.emit(Event::SoldOut(SoldOut { time: current_time }));
             };
 
-            // [Return] cc distribution
-            cc_distribution
+            // [Return] cc shares
+            cc_shares
         }
     }
 }

--- a/src/contracts/project.cairo
+++ b/src/contracts/project.cairo
@@ -12,9 +12,7 @@ trait IExternal<ContractState> {
     fn decimals(self: @ContractState) -> u8;
     fn balance(self: @ContractState, account: ContractAddress, token_id: u256) -> u256;
     /// Returns the carbon credit balance of the user for the given vintage.
-    fn balance_of_shares(
-        self: @ContractState, account: ContractAddress, token_id: u256
-    ) -> u256;
+    fn balance_of_shares(self: @ContractState, account: ContractAddress, token_id: u256) -> u256;
     fn only_owner(self: @ContractState);
 }
 

--- a/tests/test_carbon_handler.cairo
+++ b/tests/test_carbon_handler.cairo
@@ -100,9 +100,7 @@ fn setup_project(
 }
 
 /// Mint shares without the minter contract. Testing purposes only.
-fn mint_utils(
-    project_address: ContractAddress, owner_address: ContractAddress, share: u256
-) {
+fn mint_utils(project_address: ContractAddress, owner_address: ContractAddress, share: u256) {
     let cc_handler = ICarbonCreditsHandlerDispatcher { contract_address: project_address };
     let cc_years_vintages: Span<u256> = cc_handler.get_years_vintage();
     let n = cc_years_vintages.len();
@@ -495,11 +493,11 @@ fn test_rebase_half_supply() {
             break;
         }
         let old_vintage_supply = cc_handler.get_vintage_supply(*cc_years_vintages.at(index));
-        let old_cc_balance = project.balance(owner_address, *cc_years_vintages.at(index));
+        let old_cc_balance = project.balance_of(owner_address, *cc_years_vintages.at(index));
         // rebase
         absorber.rebase_vintage(*cc_years_vintages.at(index), old_vintage_supply / 2);
         let new_vintage_supply = cc_handler.get_vintage_supply(*cc_years_vintages.at(index));
-        let new_cc_balance = project.balance(owner_address, *cc_years_vintages.at(index));
+        let new_cc_balance = project.balance_of(owner_address, *cc_years_vintages.at(index));
         assert(new_vintage_supply == old_vintage_supply / 2, 'rebase not correct');
         assert(new_cc_balance == old_cc_balance / 2, 'rebase not correct');
         index += 1;

--- a/tests/test_carbon_handler.cairo
+++ b/tests/test_carbon_handler.cairo
@@ -101,9 +101,7 @@ fn setup_project(
 
 /// Mint carbon credits without the minter contract. Testing purposes only.
 fn mint_carbon_credits(
-    project_address: ContractAddress,
-    owner_address: ContractAddress,
-    share: u256
+    project_address: ContractAddress, owner_address: ContractAddress, share: u256
 ) {
     let cc_handler = ICarbonCreditsHandlerDispatcher { contract_address: project_address };
     let cc_years_vintages: Span<u256> = cc_handler.get_years_vintage();
@@ -119,7 +117,7 @@ fn mint_carbon_credits(
         index += 1;
     };
     let cc_shares = cc_shares.span();
-    
+
     let project = IProjectDispatcher { contract_address: project_address };
     project.batch_mint(owner_address, cc_years_vintages, cc_shares);
 }
@@ -499,11 +497,11 @@ fn test_rebase_half_supply() {
         let old_vintage_supply = cc_handler.get_vintage_supply(*cc_years_vintages.at(index));
         let old_cc_balance = project.balance(owner_address, *cc_years_vintages.at(index));
         // rebase
-        absorber.rebase_vintage(*cc_years_vintages.at(index), old_vintage_supply/2);
+        absorber.rebase_vintage(*cc_years_vintages.at(index), old_vintage_supply / 2);
         let new_vintage_supply = cc_handler.get_vintage_supply(*cc_years_vintages.at(index));
         let new_cc_balance = project.balance(owner_address, *cc_years_vintages.at(index));
-        assert(new_vintage_supply == old_vintage_supply/2, 'rebase not correct');
-        assert(new_cc_balance == old_cc_balance/2, 'rebase not correct');
+        assert(new_vintage_supply == old_vintage_supply / 2, 'rebase not correct');
+        assert(new_cc_balance == old_cc_balance / 2, 'rebase not correct');
         index += 1;
     };
 }

--- a/tests/test_carbon_handler.cairo
+++ b/tests/test_carbon_handler.cairo
@@ -99,8 +99,8 @@ fn setup_project(
     project.set_project_carbon(project_carbon);
 }
 
-/// Mint carbon credits without the minter contract. Testing purposes only.
-fn mint_carbon_credits(
+/// Mint shares without the minter contract. Testing purposes only.
+fn mint_utils(
     project_address: ContractAddress, owner_address: ContractAddress, share: u256
 ) {
     let cc_handler = ICarbonCreditsHandlerDispatcher { contract_address: project_address };
@@ -484,7 +484,7 @@ fn test_rebase_half_supply() {
     let project = IProjectDispatcher { contract_address: project_address };
     let cc_handler = ICarbonCreditsHandlerDispatcher { contract_address: project_address };
     let share = 500000; // 50%
-    mint_carbon_credits(project_address, owner_address, share);
+    mint_utils(project_address, owner_address, share);
 
     let cc_years_vintages: Span<u256> = cc_handler.get_years_vintage();
 

--- a/tests/test_carbon_handler.cairo
+++ b/tests/test_carbon_handler.cairo
@@ -99,6 +99,31 @@ fn setup_project(
     project.set_project_carbon(project_carbon);
 }
 
+/// Mint carbon credits without the minter contract. Testing purposes only.
+fn mint_carbon_credits(
+    project_address: ContractAddress,
+    owner_address: ContractAddress,
+    share: u256
+) {
+    let cc_handler = ICarbonCreditsHandlerDispatcher { contract_address: project_address };
+    let cc_years_vintages: Span<u256> = cc_handler.get_years_vintage();
+    let n = cc_years_vintages.len();
+
+    let mut cc_shares: Array<u256> = ArrayTrait::<u256>::new();
+    let mut index = 0;
+    loop {
+        if index == n {
+            break;
+        }
+        cc_shares.append(share);
+        index += 1;
+    };
+    let cc_shares = cc_shares.span();
+    
+    let project = IProjectDispatcher { contract_address: project_address };
+    project.batch_mint(owner_address, cc_years_vintages, cc_shares);
+}
+
 //
 // Tests
 //
@@ -402,3 +427,84 @@ fn test_get_cc_vintages() {
         index += 1;
     }
 }
+
+#[test]
+fn test_rebase_half_supply() {
+    let owner_address: ContractAddress = contract_address_const::<'owner'>();
+    let (project_address, _) = deploy_project(owner_address);
+
+    let times: Span<u64> = array![
+        1674579600,
+        1706115600,
+        1737738000,
+        1769274000,
+        1800810000,
+        1832346000,
+        1863968400,
+        1895504400,
+        1927040400,
+        1958576400,
+        1990198800,
+        2021734800,
+        2053270800,
+        2084806800,
+        2116429200,
+        2147965200,
+        2179501200,
+        2211037200,
+        2242659600,
+        2274195600
+    ]
+        .span();
+
+    let absorptions: Span<u64> = array![
+        0,
+        29609535,
+        47991466,
+        88828605,
+        118438140,
+        370922507,
+        623406874,
+        875891241,
+        1128375608,
+        1380859976,
+        2076175721,
+        2771491466,
+        3466807212,
+        4162122957,
+        4857438703,
+        5552754448,
+        6248070193,
+        6943385939,
+        7638701684,
+        8000000000
+    ]
+        .span();
+
+    setup_project(project_address, 8000000000, times, absorptions,);
+    let absorber = IAbsorberDispatcher { contract_address: project_address };
+    let project = IProjectDispatcher { contract_address: project_address };
+    let cc_handler = ICarbonCreditsHandlerDispatcher { contract_address: project_address };
+    let share = 500000; // 50%
+    mint_carbon_credits(project_address, owner_address, share);
+
+    let cc_years_vintages: Span<u256> = cc_handler.get_years_vintage();
+
+    // Rebase every vintage with half the supply
+    let mut index = 0;
+    loop {
+        if index == cc_years_vintages.len() {
+            break;
+        }
+        let old_vintage_supply = cc_handler.get_vintage_supply(*cc_years_vintages.at(index));
+        let old_cc_balance = project.balance(owner_address, *cc_years_vintages.at(index));
+        // rebase
+        absorber.rebase_vintage(*cc_years_vintages.at(index), old_vintage_supply/2);
+        let new_vintage_supply = cc_handler.get_vintage_supply(*cc_years_vintages.at(index));
+        let new_cc_balance = project.balance(owner_address, *cc_years_vintages.at(index));
+        assert(new_vintage_supply == old_vintage_supply/2, 'rebase not correct');
+        assert(new_cc_balance == old_cc_balance/2, 'rebase not correct');
+        index += 1;
+    };
+}
+

--- a/tests/test_project.cairo
+++ b/tests/test_project.cairo
@@ -145,7 +145,7 @@ fn test_project_batch_mint() {
     let decimal: u8 = project_contract.decimals();
     assert(decimal == 6, 'Error of decimal');
 
-    let balance: u256 = project_contract.balance(owner_address, 2027);
+    let balance: u256 = project_contract.balance_of(owner_address, 2027);
     assert(balance == 0, 'Error of balance');
 
     let share: u256 = 125000;


### PR DESCRIPTION
closes #38

- Users are now minting and holding shares of the total supply
- In project.cairo, `balance` still returns the carbon_credits amount and not the shares thanks to the `share_to_cc` function.
- erc1155 abi isn't embed anymore => reimplementation of all the functions in the `project.cairo` to keep compatibility.

**/!\\** Because internal balance is now using shares of supply, but the balance used by users are cc tokens, we need to use converters like `cc_to_share` and `share_to_cc`. There are rounding errors that needs to be solved, will be done in an other PR.