### PR TITLE
README + Contribution guidelines

### DIFF
--- a/Contributing.md
+++ b/Contributing.md
@@ -1,0 +1,74 @@
+# Contributing to Carbon Protocol V3
+
+First off, thank you for considering contributing to Carbon Protocol V3! Contributions are what make the open-source community such an amazing place to learn, inspire, and create. Any contributions you make are **greatly appreciated**.
+
+## How Can I Contribute?
+
+### 🌡️ Reporting Bugs
+
+If you find a bug, please open an issue using the [bug report template](https://github.com/carbonable-labs/carbon-protocol-v3/issues/new?assignees=&labels=bug&template=01_BUG_REPORT.md&title=bug%3A+). Be sure to include a clear title and description, as much relevant information as possible, and a code sample or screenshot if applicable.
+
+### 📝 Requesting Features
+
+If you have an idea for a new feature, please submit a feature request using the [feature request template](https://github.com/carbonable-labs/carbon-protocol-v3/issues/new?assignees=&labels=enhancement&template=02_FEATURE_REQUEST.md&title=feat%3A+). Include a clear and concise description of the feature, why it would be useful, and any additional context. You can also contact us through Discord or Telegram to discuss about it.
+
+## ⛏️ Submitting Pull Requests
+1. **Choose an issue**: Pick an unassigned issue and ask for more information if needed via Telegram or Discord.
+2. **Fork the repository**: Click the "Fork" button on the top right of the repository page and create a new branch dedicated to the issue.
+3. **Code your changes**: Implement your feature or fix the bug. Follow the project's coding style and commit message principles.
+4. **Test your changes**: Ensure that all tests pass and your changes do not break existing functionality.
+5. **Submit your changes**: Push your changes and open a new pull request with a clear description of your changes and link to any relevant issues.
+
+## 📦 Project Setup
+
+#### Requirements
+
+- [Scarb](https://docs.swmansion.com/scarb/): *v2.5.4*
+- [Starknet Foundry](https://foundry-rs.github.io/starknet-foundry/index.html) *v0.18.0*
+
+We recommend installing dependencies using [asdf](https://asdf-vm.com/):
+
+```bash
+asdf install scarb 2.5.4
+asdf install starknet-foundry 0.18.0
+```
+
+#### Compile
+
+To compile the project, run:
+```bash
+scarb build
+```
+
+#### Code Style
+To format the code, run:
+
+```bash
+scarb fmt
+```
+
+#### Testing
+To run tests (using Starknet-Foundry), use:
+
+```bash
+scarb test
+```
+
+To run a specific test:
+```bash
+scarb test <name_of_the_test>
+```
+
+### Guidelines
+- All tests should be placed in the `tests/` folder.
+- Tests should be organized according to the tested file and function.
+- Refer to existing tests for coding style and structure.
+- Use utility functions from `tests/tests_lib.cairo` to set up your tests and avoid redundancy (especially `default_setup_and_deploy` and `buy_utils`).
+
+### License
+By contributing to Carbon Protocol V3, you agree that your contributions will be licensed under the License used.
+
+### Thank You
+Thank you for your interest in contributing to Carbon Protocol V3! We look forward to building something great together.
+
+

--- a/README.md
+++ b/README.md
@@ -1,1 +1,85 @@
-# carbon-protocol-v3
+<div align="center">
+  <h1 align="center">Carbon Protocol V3 on Starknet</h1>
+  <h3 align="center">Leading Web3 Infrastructure to Manage Real-World Assets (RWA)</h3>
+  <img src="https://user-images.githubusercontent.com/25151724/214644164-61d5718b-fcf3-474e-9cdb-135836416e68.png" height="200">
+  <br />
+  <p align="center">
+    <a href="https://discord.gg/twyWfTGd6m">
+        <img src="https://img.shields.io/badge/Discord-6666FF?style=for-the-badge&logo=discord&logoColor=white">
+    </a>
+    <a href="https://twitter.com/intent/follow?screen_name=Carbonable_io">
+        <img src="https://img.shields.io/badge/Twitter-1DA1F2?style=for-the-badge&logo=twitter&logoColor=white">
+    </a>       
+  </p>
+  <a href="https://github.com/carbonable-labs/carbon-protocol-v3/issues/new?assignees=&labels=bug&template=01_BUG_REPORT.md&title=bug%3A+">Report a Bug</a>
+  -
+  <a href="https://github.com/carbonable-labs/carbon-protocol-v3/issues/new?assignees=&labels=enhancement&template=02_FEATURE_REQUEST.md&title=feat%3A+">Request a Feature</a>
+  -
+  <a href="https://github.com/carbonable-labs/carbon-protocol-v3/discussions">Ask a Question</a>
+</div>
+
+<div align="center">
+<br />
+</div>
+
+## About
+
+Carbon Protocol V3 is a cutting-edge, open-source tool designed for the tokenization, trading, and management of carbon credits on Starknet.
+
+To learn more about key topics:
+- [Carbon-Protocol v2](https://github.com/Carbonable/carbon-protocol)
+- [EIP-1155](https://eips.ethereum.org/EIPS/eip-1155)
+- [EIP-6551](https://eips.ethereum.org/EIPS/eip-6551)
+
+
+## Roadmap
+
+See the [open issues](https://github.com/carbonable-labs/carbon-protocol-v3/issues) for a list of proposed features (and known issues).
+
+## Support
+
+Reach out to the maintainer at one of the following places:
+- [GitHub Discussions](https://github.com/carbonable-labs/carbon-protocol-v3/discussions)
+- [Discord](https://discord.gg/twyWfTGd6m")
+- [Telegram](https://t.me/carbonableOD)
+
+## Project Assistance
+
+If you want to say **thank you** or/and support active development:
+- Add a [GitHub Star](https://github.com/carbonable-labs/carbon-protocol-v3) to the project.
+- Write interesting articles about the project on [Dev.to](https://dev.to/), [Medium](https://medium.com/), or your personal blog.
+
+Together, we can make Carbon Protocol V3 **better**!
+
+## Contributing
+
+First off, thanks for taking the time to contribute! Contributions are what make the open-source community such an amazing place to learn, inspire, and create. Any contributions you make will benefit everybody else and are **greatly appreciated**.
+
+Please read [our contribution guidelines](CONTRIBUTING.md), and thank you for being involved!
+
+## Authors & Contributors
+
+For a full list of all authors and contributors, see the [contributors page](https://github.com/carbonable-labs/carbon-protocol-v3/contributors).
+
+
+## License
+
+Carbon Protocol V3 follows good practices of security, but 100% security cannot be assured. Carbon Protocol V3 is in development phase and provided **"as is"** without any **warranty**.
+
+This project is licensed under the **Apache License, Version 2.0**. See [LICENSE](LICENSE) for more information.
+
+## Contributors ✨
+
+Thanks go to these wonderful people ([emoji key](https://allcontributors.org/docs/en/emoji-key)):
+
+<!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->
+<!-- prettier-ignore-start -->
+<!-- markdownlint-disable -->
+
+
+<!-- markdownlint-restore -->
+<!-- prettier-ignore-end -->
+
+<!-- ALL-CONTRIBUTORS-LIST:END -->
+
+This project follows the [all-contributors](https://github.com/all-contributors/all-contributors) specification. Contributions of any kind are welcome!


### PR DESCRIPTION
closes #65 

To onboard new contributors easily and smoothly.
The image used is the one from the carbonmeter readme, if we got a more suitable picture for cpv3 we should use it.

The `Contributors` part in the readme isn't implemented yet, will be done in an other issue.