### PR TITLE
[DevOps] Github Action - Automatize test runner at merge

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,7 +31,6 @@ jobs:
   
           # Extract summary information
           echo "::group::Summary"
-          echo "Tests summary stadistics:"
           total_tests=$(echo "$tests_output" | awk '/Tests:/{print $2}')
           tests_passed=$(echo "$tests_output" | awk '/Tests:/{print $4}')
           tests_failed=$(echo "$tests_output" | awk '/Tests:/{print $6}')

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,3 +26,11 @@ jobs:
       - name: Run Cairo tests
         id: cairo_tests
         run: bash scripts/run_tests.sh
+      
+      - name: Commit and push changes to README
+        run: |
+          git config --local user.email "action@github.com"
+          git config --local user.name "GitHub Action"
+          git add README.md
+          git commit -m "Update passed tests count and badge in README"
+          git push

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,12 +1,14 @@
 name: Run Tests
 on:
-  push:
-    branches:
-    - main
+  pull_request:
+    types:
+      - closed
 
 jobs:
   check:
     runs-on: ubuntu-latest
+    if: github.event.pull_request.merged == true && github.event.pull_request.base.ref == 'main'
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
@@ -18,6 +20,8 @@ jobs:
       
       - name: Setup snfoundry
         uses: foundry-rs/setup-snfoundry@v3
+        with:
+          snforge-version: "0.18.0"
           
       - name: Run tests
         id: test

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,25 +31,21 @@ jobs:
   
           # Extract summary information
           echo "::group::Summary"
-          passed_count=$(echo "$tests_output" | grep -oP 'passed: \K\d+')
-          failed_count=$(echo "$tests_output" | grep -oP 'failed: \K\d+')
-          skipped_count=$(echo "$tests_output" | grep -oP 'skipped: \K\d+')
-          ignored_count=$(echo "$tests_output" | grep -oP 'ignored: \K\d+')
-          filtered_out_count=$(echo "$tests_output" | grep -oP 'filtered out: \K\d+')
-
-          # Calculate total tests
-          total_tests=$(( passed_count + failed_count + skipped_count + ignored_count + filtered_out_count ))
-          
-          echo "Total tests: $total_tests"
-          echo "Total passed tests: $passed_count"
-          echo "Total failed tests: $failed_count"
+          tests_passed=$(echo "$tests_output" | awk '/Tests:/{print $2}')
+          tests_failed=$(echo "$tests_output" | awk '/Tests:/{print $4}')
+          skipped_count=$(echo "$tests_output" | awk '/Tests:/{print $6}')
+          ignored_count=$(echo "$tests_output" | awk '/Tests:/{print $6}')
+          filtered_out_count=$(echo "$tests_output" | awk '/Tests:/{print $6}')
+          # echo "Total tests: $total_tests"
+          echo "Total passed tests: $tests_passed"
+          echo "Total failed tests: $tests_failed"
           echo "Total skipped tests: $skipped_count"
           echo "Total ignored tests: $ignored_count"
           echo "Total filtered out tests: $filtered_out_count"
           echo "::endgroup::"
   
           # Check if any test failed
-          if [ "$failed_count" -gt 0 ]; then
+          if [ "$tests_failed" -gt 0 ]; then
             failed_tests=$(echo "$tests_output" | awk '/Failures:/{flag=1;next}/^\s*$/{flag=0}flag')
             echo "::error::Tests failed:"
             echo "$failed_tests"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -33,9 +33,9 @@ jobs:
           total_tests=$(echo "$tests_output" | awk '/Tests:/{print $2}')
           tests_passed=$(echo "$tests_output" | awk '/Tests:/{print $4}')
           tests_failed=$(echo "$tests_output" | awk '/Tests:/{print $6}')
-          echo "::set-output name=total_tests::$total_tests"
-          echo "::set-output name=tests_passed::$tests_passed"
-          echo "::set-output name=tests_failed::$tests_failed"
+          echo "total_tests=$total_tests" >> $GITHUB_OUTPUT
+          echo "tests_passed=$tests_passed" >> $GITHUB_OUTPUT
+          echo "tests_failed=$tests_failed" >> $GITHUB_OUTPUT
   
           # Check if any test failed
           if echo "$tests_output" | grep -q '\[FAIL\]'; then

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,35 @@
+name: Run Tests
+on:
+  push:
+    branches:
+    - main
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Setup Scarb
+        uses: software-mansion/setup-scarb@v1
+        with:
+          scarb-version: "2.5.4"
+      
+      - name: Setup snfoundry
+        uses: foundry-rs/setup-snfoundry@v3
+          
+      - name: Run tests
+        id: test
+        run: |
+          set -e
+          if ! scarb run test; then
+            echo "::error::One or more Scarb tests failed. See above for details."
+            exit 1
+          fi
+
+      - name: Check test status
+        if: ${{ failure() }}
+        run: |
+          echo "Tests failed!"
+          exit 1

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,17 +23,24 @@ jobs:
         with:
           starknet-foundry-version: "0.18.0"
           
-      - name: Run tests
+      - name: Run Cairo tests
         id: cairo_tests
         run: |
           set -e
           tests_output=$(scarb run test || true)
-          echo "$tests_output"
+  
+          # Extract summary information
+          total_tests=$(echo "$tests_output" | awk '/Tests:/{print $2}')
+          tests_passed=$(echo "$tests_output" | awk '/Tests:/{print $4}')
+          tests_failed=$(echo "$tests_output" | awk '/Tests:/{print $6}')
+          echo "::set-output name=total_tests::$total_tests"
+          echo "::set-output name=tests_passed::$tests_passed"
+          echo "::set-output name=tests_failed::$tests_failed"
   
           # Check if any test failed
           if echo "$tests_output" | grep -q '\[FAIL\]'; then
-          failed_test=$(echo "$tests_output" | awk -F ' :: ' '/\[FAIL\]/ {print $2}')
-          echo "\n\n TEST FAILED:"
-          echo "$failed_test"
-          exit 1
+            failed_tests=$(echo "$tests_output" | awk '/Failures:/{flag=1;next}/^\s*$/{flag=0}flag')
+            echo "::error::Tests failed:"
+            echo "$failed_tests"
+            exit 1
           fi

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,12 +31,21 @@ jobs:
   
           # Extract summary information
           echo "::group::Summary"
-          total_tests=$(echo "$tests_output" | awk '/Tests:/{print $2}')
-          tests_passed=$(echo "$tests_output" | awk '/Tests:/{print $4}')
-          tests_failed=$(echo "$tests_output" | awk '/Tests:/{print $6}')
+          passed_count=$(echo "$tests_output" | awk -F '[,:] ' '/passed/ {print $2}')
+          failed_count=$(echo "$tests_output" | awk -F '[,:] ' '/failed/ {print $2}')
+          skipped_count=$(echo "$tests_output" | awk -F '[,:] ' '/skipped/ {print $2}')
+          ignored_count=$(echo "$tests_output" | awk -F '[,:] ' '/ignored/ {print $2}')
+          filtered_out_count=$(echo "$tests_output" | awk -F '[,:] ' '/filtered out/ {print $2}')
+
+          # Calculate total tests
+          total_tests=$(( passed_count + failed_count + skipped_count + ignored_count + filtered_out_count ))
+          
           echo "Total tests: $total_tests"
-          echo "Total passed tests: $tests_passed"
-          echo "Total failed tests: $tests_failed"
+          echo "Total passed tests: $passed_count"
+          echo "Total failed tests: $failed_count"
+          echo "Total skipped tests: $skipped_count"
+          echo "Total ignored tests: $ignored_count"
+          echo "Total filtered out tests: $filtered_out_count"
           echo "::endgroup::"
   
           # Check if any test failed
@@ -46,3 +55,4 @@ jobs:
             echo "$failed_tests"
             exit 1
           fi
+          

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup snfoundry
         uses: foundry-rs/setup-snfoundry@v3
         with:
-          snforge-version: "0.18.0"
+          starknet-foundry-version: "0.18.0"
           
       - name: Run tests
         id: test

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,11 +31,11 @@ jobs:
   
           # Extract summary information
           echo "::group::Summary"
-          passed_count=$(echo "$tests_output" | awk -F '[,:] ' '/passed/ {print $2}')
-          failed_count=$(echo "$tests_output" | awk -F '[,:] ' '/failed/ {print $2}')
-          skipped_count=$(echo "$tests_output" | awk -F '[,:] ' '/skipped/ {print $2}')
-          ignored_count=$(echo "$tests_output" | awk -F '[,:] ' '/ignored/ {print $2}')
-          filtered_out_count=$(echo "$tests_output" | awk -F '[,:] ' '/filtered out/ {print $2}')
+          passed_count=$(echo "$tests_output" | grep -oP 'passed: \K\d+')
+          failed_count=$(echo "$tests_output" | grep -oP 'failed: \K\d+')
+          skipped_count=$(echo "$tests_output" | grep -oP 'skipped: \K\d+')
+          ignored_count=$(echo "$tests_output" | grep -oP 'ignored: \K\d+')
+          filtered_out_count=$(echo "$tests_output" | grep -oP 'filtered out: \K\d+')
 
           # Calculate total tests
           total_tests=$(( passed_count + failed_count + skipped_count + ignored_count + filtered_out_count ))
@@ -49,10 +49,9 @@ jobs:
           echo "::endgroup::"
   
           # Check if any test failed
-          if echo "$tests_output" | grep -q '\[FAIL\]'; then
+          if [ "$failed_count" -gt 0 ]; then
             failed_tests=$(echo "$tests_output" | awk '/Failures:/{flag=1;next}/^\s*$/{flag=0}flag')
             echo "::error::Tests failed:"
             echo "$failed_tests"
             exit 1
           fi
-          

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,16 +24,16 @@ jobs:
           starknet-foundry-version: "0.18.0"
           
       - name: Run tests
-        id: test
+        id: cairo_tests
         run: |
           set -e
-          if ! scarb run test; then
-            echo "::error::One or more Scarb tests failed. See above for details."
-            exit 1
-          fi
-
-      - name: Check test status
-        if: ${{ failure() }}
-        run: |
-          echo "Tests failed!"
+          tests_output=$(scarb run test || true)
+          echo "$tests_output"
+  
+          # Check if any test failed
+          if echo "$tests_output" | grep -q '\[FAIL\]'; then
+          failed_test=$(echo "$tests_output" | awk -F ' :: ' '/\[FAIL\]/ {print $2}')
+          echo "\n\n TEST FAILED:"
+          echo "$failed_test"
           exit 1
+          fi

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,12 +30,15 @@ jobs:
           tests_output=$(scarb run test || true)
   
           # Extract summary information
+          echo "::group::Summary"
+          echo "Tests summary stadistics:"
           total_tests=$(echo "$tests_output" | awk '/Tests:/{print $2}')
           tests_passed=$(echo "$tests_output" | awk '/Tests:/{print $4}')
           tests_failed=$(echo "$tests_output" | awk '/Tests:/{print $6}')
-          echo "total_tests=$total_tests" >> $GITHUB_OUTPUT
-          echo "tests_passed=$tests_passed" >> $GITHUB_OUTPUT
-          echo "tests_failed=$tests_failed" >> $GITHUB_OUTPUT
+          echo "Total tests: $total_tests"
+          echo "Total passed tests: $tests_passed"
+          echo "Total failed tests: $tests_failed"
+          echo "::endgroup::"
   
           # Check if any test failed
           if echo "$tests_output" | grep -q '\[FAIL\]'; then

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,29 +25,4 @@ jobs:
           
       - name: Run Cairo tests
         id: cairo_tests
-        run: |
-          set -e
-          tests_output=$(scarb run test || true)
-  
-          # Extract summary information
-          echo "::group::Summary"
-          tests_passed=$(echo "$tests_output" | awk '/Tests:/{print $2}')
-          tests_failed=$(echo "$tests_output" | awk '/Tests:/{print $4}')
-          skipped_count=$(echo "$tests_output" | awk '/Tests:/{print $6}')
-          ignored_count=$(echo "$tests_output" | awk '/Tests:/{print $6}')
-          filtered_out_count=$(echo "$tests_output" | awk '/Tests:/{print $6}')
-          # echo "Total tests: $total_tests"
-          echo "Total passed tests: $tests_passed"
-          echo "Total failed tests: $tests_failed"
-          echo "Total skipped tests: $skipped_count"
-          echo "Total ignored tests: $ignored_count"
-          echo "Total filtered out tests: $filtered_out_count"
-          echo "::endgroup::"
-  
-          # Check if any test failed
-          if [ "$tests_failed" -gt 0 ]; then
-            failed_tests=$(echo "$tests_output" | awk '/Failures:/{flag=1;next}/^\s*$/{flag=0}flag')
-            echo "::error::Tests failed:"
-            echo "$failed_tests"
-            exit 1
-          fi
+        run: bash scripts/run_tests.sh

--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@
 </div>
 
 ## About
+ 
+[![Tests](https://img.shields.io/badge/Tests-79%20passed-brightgreen)](README.md)
 
 Carbon Protocol V3 is a cutting-edge, open-source tool designed for the tokenization, trading, and management of carbon credits on Starknet.
 

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+set -e
+
+tests_output=$(scarb run test || true)
+
+# Extract summary information
+echo "::group::Summary"
+
+tests_passed=$(echo "$tests_output" | awk '/Tests:/{print $2}')
+tests_failed=$(echo "$tests_output" | awk '/Tests:/{print $4}')
+skipped_count=$(echo "$tests_output" | awk '/Tests:/{print $6}')
+ignored_count=$(echo "$tests_output" | awk '/Tests:/{print $6}')
+filtered_out_count=$(echo "$tests_output" | awk '/Tests:/{print $6}')
+
+echo "Total passed tests: $tests_passed"
+echo "Total failed tests: $tests_failed"
+echo "Total skipped tests: $skipped_count"
+echo "Total ignored tests: $ignored_count"
+echo "Total filtered out tests: $filtered_out_count"
+echo "::endgroup::"
+  
+# Check if any test failed
+if [ "$tests_failed" -gt 0 ]; then
+  failed_tests=$(echo "$tests_output" | awk '/Failures:/{flag=1;next}/^\s*$/{flag=0}flag')
+  echo "::error::Tests failed:"
+  echo "$failed_tests"
+  exit 1
+fi

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -28,17 +28,18 @@ if [ "$tests_failed" -gt 0 ]; then
   exit 1
 fi
 
+# Generate badge markdown
+badge="[![Tests](https://img.shields.io/badge/Tests-Passed-brightgreen)](README.md)"
+
 # Check if badge already exists in README
 if ! grep -q '\[!\[Tests\]' README.md; then
-  # Badge markdown to add if not present
-  badge="[![Tests](https://img.shields.io/badge/Tests-Passed-brightgreen)](README.md)"
+  # Add badge markdown at the top if not present
   echo "$badge" > badge_temp
   sed -i '1s/^/'"$badge"'\n\n/' README.md
 fi
 
+# Update passed tests count in README
 echo "Passed tests: $tests_passed" > temp_file
-
-# Replace passed tests count in README
 sed -i 's/\(Passed tests: \).*/\1'"$tests_passed"'/' README.md
 
 # Clean up temporary files

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -27,3 +27,19 @@ if [ "$tests_failed" -gt 0 ]; then
   echo "$failed_tests"
   exit 1
 fi
+
+# Check if badge already exists in README
+if ! grep -q '\[!\[Tests\]' README.md; then
+  # Badge markdown to add if not present
+  badge="[![Tests](https://img.shields.io/badge/Tests-Passed-brightgreen)](README.md)"
+  echo "$badge" > badge_temp
+  sed -i '1s/^/'"$badge"'\n\n/' README.md
+fi
+
+echo "Passed tests: $tests_passed" > temp_file
+
+# Replace passed tests count in README
+sed -i 's/\(Passed tests: \).*/\1'"$tests_passed"'/' README.md
+
+# Clean up temporary files
+rm temp_file badge_temp

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -29,18 +29,17 @@ if [ "$tests_failed" -gt 0 ]; then
 fi
 
 # Generate badge markdown
-badge="[![Tests](https://img.shields.io/badge/Tests-Passed-brightgreen)](README.md)"
+badge="[![Tests](https://img.shields.io/badge/Tests-${tests_passed}%20passed-brightgreen)](README.md)"
 
 # Check if badge already exists in README
 if ! grep -q '\[!\[Tests\]' README.md; then
   # Add badge markdown at the top if not present
-  echo "$badge" > badge_temp
-  sed -i '1s/^/'"$badge"'\n\n/' README.md
+  echo -e "\n" >> README.md
+  echo "## Tests" >> README.md
+  echo -e "\n" >> README.md
+  echo "$badge" >> README.md
+
+else
+  # Replace existing badge with new badge
+  sed -i '' "s|\[!\[Tests\].*|$badge|" README.md
 fi
-
-# Update passed tests count in README
-echo "Passed tests: $tests_passed" > temp_file
-sed -i 's/\(Passed tests: \).*/\1'"$tests_passed"'/' README.md
-
-# Clean up temporary files
-rm temp_file badge_temp

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -19,7 +19,7 @@ echo "Total skipped tests: $skipped_count"
 echo "Total ignored tests: $ignored_count"
 echo "Total filtered out tests: $filtered_out_count"
 echo "::endgroup::"
-  
+
 # Check if any test failed
 if [ "$tests_failed" -gt 0 ]; then
   failed_tests=$(echo "$tests_output" | awk '/Failures:/{flag=1;next}/^\s*$/{flag=0}flag')
@@ -31,15 +31,11 @@ fi
 # Generate badge markdown
 badge="[![Tests](https://img.shields.io/badge/Tests-${tests_passed}%20passed-brightgreen)](README.md)"
 
-# Check if badge already exists in README
-if ! grep -q '\[!\[Tests\]' README.md; then
-  # Add badge markdown at the top if not present
-  echo -e "\n" >> README.md
-  echo "## Tests" >> README.md
-  echo -e "\n" >> README.md
-  echo "$badge" >> README.md
-
+# Replace or add the badge below "## About"
+if grep -q '\[!\[Tests\]' README.md; then
+  # Replace the existing badge
+  sed -i "s|\[!\[Tests\].*|$badge|" README.md
 else
-  # Replace existing badge with new badge
-  sed -i '' "s|\[!\[Tests\].*|$badge|" README.md
+  # Add the badge below "## About"
+  sed -i "/## About/a \ \n$badge\n" README.md
 fi

--- a/tests/test_carbon_handler.cairo
+++ b/tests/test_carbon_handler.cairo
@@ -434,7 +434,7 @@ fn test_share_to_cc_zero_share() {
 fn test_share_to_cc_revert_exceeds_supply() {
     let (project_address, _) = default_setup_and_deploy();
     let project = IAbsorberDispatcher { contract_address: project_address };
-    let share: u256 = 2 * CC_DECIMALS_MULTIPLIER; // share is greater than 100%
+    let share: u256 = 2 * 0; // share is greater than 100%
     project.share_to_cc(share, 2025);
 }
 

--- a/tests/test_carbon_handler.cairo
+++ b/tests/test_carbon_handler.cairo
@@ -434,7 +434,7 @@ fn test_share_to_cc_zero_share() {
 fn test_share_to_cc_revert_exceeds_supply() {
     let (project_address, _) = default_setup_and_deploy();
     let project = IAbsorberDispatcher { contract_address: project_address };
-    let share: u256 = 2 * 0; // share is greater than 100%
+    let share: u256 = 2 * CC_DECIMALS_MULTIPLIER; // share is greater than 100%
     project.share_to_cc(share, 2025);
 }
 


### PR DESCRIPTION
# Solves
closes #68  

# Description

As Carbonable, we want to use Github action to launch tests during CI/CD when we merge on main. CI should fail if all tests don't pass.

# Acceptance Criteria
- [X] Implement Github Action to launch tests through a script in bash.
- [X] If some test fails, CI should fail and a message should explain which test crashed.
- [X] Config to trigger this Github action only when PR are merged in Main branch

# Solution

A new GitHub action workflow was added to the repo. It was configured to be triggered on PR merged to main.
The workflow steps include:

1. The Scarb Setup with version 2.5.4
2. The snfoundry setup with version 0.18.0
3. Run the tests (scarb test)
4. Extract the statistics from the tests output (total passed tests, failed, skipped, etc) to display them in a more user friendly way, instead the whole test output.
5. If one or more tests failed, display which one(s) have an error and the CI fails.

# Examples

Test failed:
![Screenshot 2024-06-25 at 13 40 24](https://github.com/carbonable-labs/carbon-protocol-v3/assets/87027508/2a9aafe9-6c24-4c14-bbd3-c528c36e6761)

Success:
![Screenshot 2024-06-25 at 13 57 30](https://github.com/carbonable-labs/carbon-protocol-v3/assets/87027508/62302ca1-7a27-4397-bc77-0092f316e178)
