### PR TITLE
User as main caller for tests

### DIFF
--- a/src/components/absorber/carbon_handler.cairo
+++ b/src/components/absorber/carbon_handler.cairo
@@ -246,6 +246,11 @@ mod AbsorberComponent {
         fn rebase_vintage(
             ref self: ComponentState<TContractState>, token_id: u256, new_cc_supply: u64
         ) {
+            // [Check] Caller is owner
+            let caller_address = get_caller_address();
+            let isOwner = self.get_contract().has_role(OWNER_ROLE, caller_address);
+            assert(isOwner, 'Caller is not owner');
+
             let mut vintage: CarbonVintage = self.Absorber_vintage_cc.read(token_id);
             let old_supply = vintage.supply;
 
@@ -261,7 +266,10 @@ mod AbsorberComponent {
 
     #[embeddable_as(CarbonCreditsHandlerImpl)]
     impl CarbonCreditsHandler<
-        TContractState, +HasComponent<TContractState>, +Drop<TContractState>
+        TContractState,
+        +HasComponent<TContractState>,
+        +Drop<TContractState>,
+        +IAccessControl<TContractState>
     > of ICarbonCreditsHandler<ComponentState<TContractState>> {
         fn get_cc_vintages(self: @ComponentState<TContractState>) -> Span<CarbonVintage> {
             let mut vintages = ArrayTrait::<CarbonVintage>::new();
@@ -307,6 +315,11 @@ mod AbsorberComponent {
         fn update_vintage_status(
             ref self: ComponentState<TContractState>, token_id: u64, status: u8
         ) {
+            // [Check] Caller is owner
+            let caller_address = get_caller_address();
+            let isOwner = self.get_contract().has_role(OWNER_ROLE, caller_address);
+            assert(isOwner, 'Caller is not owner');
+
             let new_status: CarbonVintageType = self.__u8_into_CarbonVintageType(status);
             let mut vintage: CarbonVintage = self.Absorber_vintage_cc.read(token_id.into());
             vintage.status = new_status;

--- a/src/components/minter/mint.cairo
+++ b/src/components/minter/mint.cairo
@@ -319,7 +319,7 @@ mod MintComponent {
             let erc20 = IERC20Dispatcher { contract_address: token_address };
             let minter_address = get_contract_address();
 
-            let success = erc20.transfer(minter_address, money_amount);
+            let success = erc20.transfer_from(caller_address, minter_address, money_amount);
             // [Check] Transfer successful
             assert(success, 'Transfer failed');
 

--- a/src/components/minter/mint.cairo
+++ b/src/components/minter/mint.cairo
@@ -346,7 +346,7 @@ mod MintComponent {
             // [Effect] Close the sale if sold out
             if self.is_sold_out() {
                 // [Effect] Close public sale
-                self.set_public_sale_open(false);
+                self.Mint_public_sale_open.write(false);
 
                 // [Event] Emit sold out event
                 self.emit(Event::SoldOut(SoldOut { time: current_time }));

--- a/src/contracts/minter.cairo
+++ b/src/contracts/minter.cairo
@@ -10,6 +10,8 @@ mod Minter {
     use openzeppelin::upgrades::upgradeable::UpgradeableComponent;
     // Mint
     use carbon_v3::components::minter::mint::MintComponent;
+    // RBAC interface
+    use openzeppelin::access::accesscontrol::interface::IAccessControl;
 
 
     component!(path: OwnableComponent, storage: ownable, event: OwnableEvent);

--- a/src/data/carbon_vintage.cairo
+++ b/src/data/carbon_vintage.cairo
@@ -97,7 +97,6 @@ mod Test {
         assert_eq!(
             res, "CarbonVintage(vintage: 2024, supply: 1000000000, failed: 10000, status: Audited)"
         );
-        println!("{}", carbon_vintage);
     }
 
     // CarbonVintageType tests

--- a/tests/test_carbon_handler.cairo
+++ b/tests/test_carbon_handler.cairo
@@ -870,7 +870,11 @@ fn test_rebase_half_supply() {
         let old_vintage_supply = cc_handler.get_carbon_vintage(*cc_vintage_years.at(index)).supply;
         let old_cc_balance = project.balance_of(owner_address, *cc_vintage_years.at(index));
         // rebase
+        // [Prank] use owner to rebase rebase_vintage
+        start_prank(CheatTarget::One(project_address), owner_address);
         absorber.rebase_vintage(*cc_vintage_years.at(index), old_vintage_supply / 2);
+        // [Prank] stop prank on absorber contract
+        stop_prank(CheatTarget::One(project_address));
         let new_vintage_supply = cc_handler.get_carbon_vintage(*cc_vintage_years.at(index)).supply;
         let new_cc_balance = project.balance_of(owner_address, *cc_vintage_years.at(index));
         let failed_tokens = cc_handler.get_carbon_vintage(*cc_vintage_years.at(index)).failed;

--- a/tests/test_carbon_handler.cairo
+++ b/tests/test_carbon_handler.cairo
@@ -51,7 +51,7 @@ use carbon_v3::contracts::project::{
 use super::tests_lib::{
     get_mock_times, get_mock_absorptions, equals_with_error, deploy_project, setup_project,
     default_setup_and_deploy, fuzzing_setup, perform_fuzzed_transfer, buy_utils, deploy_offsetter,
-    deploy_minter, deploy_erc20
+    deploy_minter, deploy_erc20, buy_utils_test
 };
 
 // Constants
@@ -837,6 +837,7 @@ fn test_update_vintage_status_invalid() {
 #[test]
 fn test_rebase_half_supply() {
     let owner_address: ContractAddress = contract_address_const::<'OWNER'>();
+    let user_address: ContractAddress = contract_address_const::<'USER'>();
     let (project_address, _) = default_setup_and_deploy();
     let (erc20_address, _) = deploy_erc20();
     let (minter_address, _) = deploy_minter(project_address, erc20_address);
@@ -845,9 +846,7 @@ fn test_rebase_half_supply() {
     let project = IProjectDispatcher { contract_address: project_address };
     let cc_handler = ICarbonCreditsHandlerDispatcher { contract_address: project_address };
 
-    // [Prank] Use owner as caller to Minter, ERC20 and Project contracts
-    start_prank(CheatTarget::One(minter_address), owner_address);
-    start_prank(CheatTarget::One(erc20_address), owner_address);
+    // [Prank] Use owner as caller to Project contract
     start_prank(CheatTarget::One(project_address), owner_address);
     // [Effect] Grant Minter role to Minter contract
     project.grant_minter_role(minter_address);
@@ -858,7 +857,7 @@ fn test_rebase_half_supply() {
 
     let share = 50 * CC_DECIMALS_MULTIPLIER / 100; // 50%
 
-    buy_utils(minter_address, erc20_address, share);
+    buy_utils_test(owner_address, user_address, minter_address, share);
 
     let cc_vintage_years: Span<u256> = cc_handler.get_vintage_years();
 

--- a/tests/test_carbon_handler.cairo
+++ b/tests/test_carbon_handler.cairo
@@ -823,6 +823,17 @@ fn test_update_vintage_status_invalid() {
     cc_handler.update_vintage_status(token_id, invalid_status);
 }
 
+#[test]
+#[should_panic(expected: 'Caller is not owner')]
+fn test_update_vintage_status_without_owner_role() {
+    let (project_address, _) = deploy_project();
+    let cc_handler = ICarbonCreditsHandlerDispatcher { contract_address: project_address };
+    let token_id: u64 = 2024;
+    let new_status: u8 = 2;
+    start_prank(CheatTarget::One(project_address), contract_address_const::<'USER'>());
+    cc_handler.update_vintage_status(token_id, new_status);
+}
+
 // #[test]  todo, what do we expect here?
 // fn test_update_vintage_status_non_existent_token_id() {
 //     let (project_address, _) = default_setup_and_deploy();

--- a/tests/test_carbon_handler.cairo
+++ b/tests/test_carbon_handler.cairo
@@ -51,7 +51,7 @@ use carbon_v3::contracts::project::{
 use super::tests_lib::{
     get_mock_times, get_mock_absorptions, equals_with_error, deploy_project, setup_project,
     default_setup_and_deploy, fuzzing_setup, perform_fuzzed_transfer, buy_utils, deploy_offsetter,
-    deploy_minter, deploy_erc20, buy_utils_test
+    deploy_minter, deploy_erc20
 };
 
 // Constants
@@ -857,7 +857,7 @@ fn test_rebase_half_supply() {
 
     let share = 50 * CC_DECIMALS_MULTIPLIER / 100; // 50%
 
-    buy_utils_test(owner_address, user_address, minter_address, share);
+    buy_utils(owner_address, user_address, minter_address, share);
 
     let cc_vintage_years: Span<u256> = cc_handler.get_vintage_years();
 

--- a/tests/test_mint.cairo
+++ b/tests/test_mint.cairo
@@ -81,35 +81,6 @@ struct Contracts {
 // Tests
 //
 
-// set_project_carbon
-
-#[test]
-fn test_set_project_carbon() {
-    let (project_address, mut spy) = deploy_project();
-    let project = IAbsorberDispatcher { contract_address: project_address };
-    // [Prank] Use owner as caller to Project contract
-    let owner_address: ContractAddress = contract_address_const::<'OWNER'>();
-    start_prank(CheatTarget::One(project_address), owner_address);
-    // [Assert] project_carbon set correctly
-    project.set_project_carbon(PROJECT_CARBON.into());
-    let fetched_value = project.get_project_carbon();
-    assert(fetched_value == PROJECT_CARBON.into(), 'project_carbon wrong value');
-    spy
-        .assert_emitted(
-            @array![
-                (
-                    project_address,
-                    AbsorberComponent::Event::ProjectValueUpdate(
-                        AbsorberComponent::ProjectValueUpdate { value: PROJECT_CARBON.into() }
-                    )
-                )
-            ]
-        );
-    // found events are removed from the spy after assertion, so the length should be 0
-    assert(spy.events.len() == 0, 'number of events should be 0');
-}
-
-
 // is_public_sale_open
 
 #[test]
@@ -151,10 +122,10 @@ fn test_set_public_sale_open_with_owner_role() {
     minter.set_public_sale_open(true);
 }
 
-// is_public_buy
+// public_buy
 
 #[test]
-fn test_is_public_buy() {
+fn test_public_buy() {
     let owner_address: ContractAddress = contract_address_const::<'OWNER'>();
     let user_address: ContractAddress = contract_address_const::<'USER'>();
     let (project_address, _) = deploy_project();
@@ -540,12 +511,10 @@ fn test_is_sold_out() {
 
     // Test after buying all the remaining money
     let remaining_money_after_buying_all = minter.get_available_money_amount();
-    println!("gets remaining money");
     assert(remaining_money_after_buying_all == 0, 'remaining money wrong');
 
     // Verify that the contract is sold out after buying all the money
     let is_sold_out_after = minter.is_sold_out();
-    println!("gets sold out");
     assert(is_sold_out_after, 'should be sold out');
 }
 

--- a/tests/test_mint.cairo
+++ b/tests/test_mint.cairo
@@ -285,11 +285,15 @@ fn test_get_available_money_amount() {
 
 #[test]
 fn test_cancel_mint() {
+    let owner_address: ContractAddress = contract_address_const::<'OWNER'>();
     let (project_address, _) = deploy_project();
     let (erc20_address, _) = deploy_erc20();
     let (minter_address, _) = deploy_minter(project_address, erc20_address);
 
     let minter = IMintDispatcher { contract_address: minter_address };
+
+    // [Prank] Use owner as caller to Minter contract
+    start_prank(CheatTarget::One(minter_address), owner_address);
 
     // Ensure the mint is not canceled initially
     let is_canceled = minter.is_canceled();

--- a/tests/test_offsetter.cairo
+++ b/tests/test_offsetter.cairo
@@ -57,7 +57,7 @@ use carbon_v3::mock::usdcarb::USDCarb;
 // Utils for testing purposes
 
 use super::tests_lib::{
-    default_setup_and_deploy, buy_utils, deploy_offsetter, deploy_erc20, deploy_minter
+    default_setup_and_deploy, buy_utils, deploy_offsetter, deploy_erc20, deploy_minter, buy_utils_test
 };
 
 // Constants
@@ -84,13 +84,13 @@ struct Contracts {
 
 #[test]
 fn test_offsetter_init() {
-    let owner_address: ContractAddress = contract_address_const::<'OWNER'>();
+    let user_address: ContractAddress = contract_address_const::<'USER'>();
     let (project_address, _) = default_setup_and_deploy();
     let (offsetter_address, _) = deploy_offsetter(project_address);
 
     let offsetter = IOffsetHandlerDispatcher { contract_address: offsetter_address };
     // [Prank] Use owner as caller to Offsetter contract
-    start_prank(CheatTarget::One(offsetter_address), owner_address);
+    start_prank(CheatTarget::One(offsetter_address), user_address);
     // [Assert] contract is empty
     let carbon_pending = offsetter.get_carbon_retired(2025);
     assert(carbon_pending == 0, 'carbon pending should be 0');
@@ -104,6 +104,7 @@ fn test_offsetter_init() {
 #[test]
 fn test_offsetter_retire_carbon_credits() {
     let owner_address: ContractAddress = contract_address_const::<'OWNER'>();
+    let user_address: ContractAddress = contract_address_const::<'USER'>();
     let (project_address, _) = default_setup_and_deploy();
     let (offsetter_address, _) = deploy_offsetter(project_address);
     let (erc20_address, _) = deploy_erc20();
@@ -111,26 +112,22 @@ fn test_offsetter_retire_carbon_credits() {
 
     // [Prank] Use owner as caller to Project, Offsetter, Minter and ERC20 contracts
     start_prank(CheatTarget::One(project_address), owner_address);
-    start_prank(CheatTarget::One(offsetter_address), owner_address);
-    start_prank(CheatTarget::One(minter_address), owner_address);
-    start_prank(CheatTarget::One(erc20_address), owner_address);
+    start_prank(CheatTarget::One(offsetter_address), user_address);
 
     let project = IProjectDispatcher { contract_address: project_address };
     // [Effect] Grant Minter contract the Minter role
     project.grant_minter_role(minter_address);
     // [Effect] Grant Offsetter contract the Offsetter role
     project.grant_offsetter_role(offsetter_address);
+    // [Prank] Stop prank on Project contract
+    stop_prank(CheatTarget::One(project_address));
 
     // [Effect] setup a batch of carbon credits
     let carbon_credits = ICarbonCreditsHandlerDispatcher { contract_address: project_address };
 
     let share: u256 = 10 * CC_DECIMALS_MULTIPLIER / 100; // 10%
-    // [Prank] Simulate production flow, Minter calls Project contract
-    start_prank(CheatTarget::One(project_address), minter_address);
-    buy_utils(minter_address, erc20_address, share);
-    // [Prank] Stop prank on Project contract
-    stop_prank(CheatTarget::One(project_address));
-    let initial_balance = project.balance_of(owner_address, 2025);
+    buy_utils_test(owner_address, user_address, minter_address, share);
+    let initial_balance = project.balance_of(user_address, 2025);
 
     // [Effect] update Vintage status
     carbon_credits.update_vintage_status(2025, CarbonVintageType::Audited.into());
@@ -142,7 +139,7 @@ fn test_offsetter_retire_carbon_credits() {
     let carbon_retired = offsetter.get_carbon_retired(2025);
     assert(carbon_retired == 100000, 'Carbon retired is wrong');
 
-    let final_balance = project.balance_of(owner_address, 2025);
+    let final_balance = project.balance_of(user_address, 2025);
     assert(final_balance == initial_balance - 100000, 'Balance is wrong');
 }
 
@@ -150,6 +147,7 @@ fn test_offsetter_retire_carbon_credits() {
 #[should_panic(expected: 'Vintage status is not audited')]
 fn test_offsetter_wrong_status() {
     let owner_address: ContractAddress = contract_address_const::<'OWNER'>();
+    let user_address: ContractAddress = contract_address_const::<'USER'>();
     let (project_address, _) = default_setup_and_deploy();
     let (offsetter_address, _) = deploy_offsetter(project_address);
     let (erc20_address, _) = deploy_erc20();
@@ -157,23 +155,20 @@ fn test_offsetter_wrong_status() {
 
     // [Prank] Use owner as caller to Project, Offsetter, Minter and ERC20 contracts
     start_prank(CheatTarget::One(project_address), owner_address);
-    start_prank(CheatTarget::One(offsetter_address), owner_address);
-    start_prank(CheatTarget::One(minter_address), owner_address);
-    start_prank(CheatTarget::One(erc20_address), owner_address);
+    start_prank(CheatTarget::One(offsetter_address), user_address);
 
     let project = IProjectDispatcher { contract_address: project_address };
     // [Effect] Grant Minter contract the Minter role
     project.grant_minter_role(minter_address);
     // [Effect] Grant Offsetter contract the Offsetter role
     project.grant_offsetter_role(offsetter_address);
+    // [Prank] Stop prank on Project contract
+    stop_prank(CheatTarget::One(project_address));
 
     // [Effect] setup a batch of carbon credits
     let share = 33 * CC_DECIMALS_MULTIPLIER / 100; // 33%
-    // [Prank] Simulate production flow, Minter calls Project contract
-    start_prank(CheatTarget::One(project_address), minter_address);
-    buy_utils(minter_address, erc20_address, share);
-    // [Prank] Stop prank on Project contract
-    stop_prank(CheatTarget::One(project_address));
+ 
+    buy_utils_test(owner_address, user_address, minter_address, share);
 
     // [Check] Vintage status is not audited
     let cc_handler = ICarbonCreditsHandlerDispatcher { contract_address: project_address };
@@ -189,6 +184,7 @@ fn test_offsetter_wrong_status() {
 #[should_panic(expected: 'Not own enough carbon credits')]
 fn test_retire_carbon_credits_insufficient_credits() {
     let owner_address: ContractAddress = contract_address_const::<'OWNER'>();
+    let user_address: ContractAddress = contract_address_const::<'USER'>();
     let (project_address, _) = default_setup_and_deploy();
     let (offsetter_address, _) = deploy_offsetter(project_address);
     let (erc20_address, _) = deploy_erc20();
@@ -196,38 +192,35 @@ fn test_retire_carbon_credits_insufficient_credits() {
 
     // [Prank] Use owner as caller to Project, Offsetter, Minter and ERC20 contracts
     start_prank(CheatTarget::One(project_address), owner_address);
-    start_prank(CheatTarget::One(offsetter_address), owner_address);
-    start_prank(CheatTarget::One(minter_address), owner_address);
-    start_prank(CheatTarget::One(erc20_address), owner_address);
+    start_prank(CheatTarget::One(offsetter_address), user_address);
 
     let project_contract = IProjectDispatcher { contract_address: project_address };
     // [Effect] Grant Minter role to Minter contract
     project_contract.grant_minter_role(minter_address);
     // [Effect] Grant Offsetter role to Offsetter contract
     project_contract.grant_offsetter_role(offsetter_address);
+    // [Prank] Stop prank on Project contract
+    stop_prank(CheatTarget::One(project_address));
 
     // [Effect] setup a batch of carbon credits
     let carbon_credits = ICarbonCreditsHandlerDispatcher { contract_address: project_address };
 
     let share = 33 * CC_DECIMALS_MULTIPLIER / 100;
-    // [Prank] Simulate production flow, Minter calls Project contract
-    start_prank(CheatTarget::One(project_address), minter_address);
-    buy_utils(minter_address, erc20_address, share);
-    // [Prank] Stop prank on Project contract
-    stop_prank(CheatTarget::One(project_address));
+    buy_utils_test(owner_address, user_address, minter_address, share);
 
     // [Effect] update Vintage status
     carbon_credits.update_vintage_status(2025, CarbonVintageType::Audited.into());
 
     // [Effect] try to retire carbon credits
     let offsetter = IOffsetHandlerDispatcher { contract_address: offsetter_address };
-    let balance_owner = project_contract.balance_of(owner_address, 2025);
-    offsetter.retire_carbon_credits(2025, balance_owner + 1);
+    let user_balance = project_contract.balance_of(user_address, 2025);
+    offsetter.retire_carbon_credits(2025, user_balance + 1);
 }
 
 #[test]
 fn test_retire_carbon_credits_exact_balance() {
     let owner_address: ContractAddress = contract_address_const::<'OWNER'>();
+    let user_address: ContractAddress = contract_address_const::<'USER'>();
     let (project_address, _) = default_setup_and_deploy();
     let (offsetter_address, _) = deploy_offsetter(project_address);
     let (erc20_address, _) = deploy_erc20();
@@ -235,44 +228,43 @@ fn test_retire_carbon_credits_exact_balance() {
 
     // [Prank] Use owner as caller to Project, Offsetter, Minter and ERC20 contracts
     start_prank(CheatTarget::One(project_address), owner_address);
-    start_prank(CheatTarget::One(offsetter_address), owner_address);
-    start_prank(CheatTarget::One(minter_address), owner_address);
-    start_prank(CheatTarget::One(erc20_address), owner_address);
+    start_prank(CheatTarget::One(offsetter_address), user_address);
 
     let project_contract = IProjectDispatcher { contract_address: project_address };
     // [Effect] Grant Minter role to Minter contract
     project_contract.grant_minter_role(minter_address);
     // [Effect] Grant Offsetter role to Offsetter contract
     project_contract.grant_offsetter_role(offsetter_address);
+    // [Prank] Stop prank on Project contract
+    stop_prank(CheatTarget::One(project_address));
 
     // [Effect] setup a batch of carbon credits
     let carbon_credits = ICarbonCreditsHandlerDispatcher { contract_address: project_address };
 
     let share = 33 * CC_DECIMALS_MULTIPLIER / 100;
-    // [Prank] Simulate production flow, Minter calls Project contract
-    start_prank(CheatTarget::One(project_address), minter_address);
-    buy_utils(minter_address, erc20_address, share);
-    // [Prank] Stop prank on Project contract
-    stop_prank(CheatTarget::One(project_address));
-    let balance_owner = project_contract.balance_of(owner_address, 2025);
+
+    buy_utils_test(owner_address, user_address, minter_address, share);
+
+    let user_balance = project_contract.balance_of(user_address, 2025);
 
     // [Effect] update Vintage status
     carbon_credits.update_vintage_status(2025, CarbonVintageType::Audited.into());
 
     // [Effect] try to retire carbon credits
     let offsetter = IOffsetHandlerDispatcher { contract_address: offsetter_address };
-    offsetter.retire_carbon_credits(2025, balance_owner);
+    offsetter.retire_carbon_credits(2025, user_balance);
 
     let carbon_retired = offsetter.get_carbon_retired(2025);
-    assert(carbon_retired == balance_owner, 'Carbon retired is wrong');
+    assert(carbon_retired == user_balance, 'Carbon retired is wrong');
 
-    let balance_owner_after = project_contract.balance_of(owner_address, 2025);
-    assert(balance_owner_after == 0, 'Balance is wrong');
+    let user_balance_after = project_contract.balance_of(user_address, 2025);
+    assert(user_balance_after == 0, 'Balance is wrong');
 }
 
 #[test]
 fn test_retire_carbon_credits_multiple_retirements() {
     let owner_address: ContractAddress = contract_address_const::<'OWNER'>();
+    let user_address: ContractAddress = contract_address_const::<'USER'>();
     let (project_address, _) = default_setup_and_deploy();
     let (offsetter_address, _) = deploy_offsetter(project_address);
     let (erc20_address, _) = deploy_erc20();
@@ -280,26 +272,24 @@ fn test_retire_carbon_credits_multiple_retirements() {
 
     // [Prank] Use owner as caller to Project, Offsetter, Minter and ERC20 contracts
     start_prank(CheatTarget::One(project_address), owner_address);
-    start_prank(CheatTarget::One(offsetter_address), owner_address);
-    start_prank(CheatTarget::One(minter_address), owner_address);
-    start_prank(CheatTarget::One(erc20_address), owner_address);
+    start_prank(CheatTarget::One(offsetter_address), user_address);
 
     let project = IProjectDispatcher { contract_address: project_address };
     // [Effect] Grant Minter role to Minter contract
     project.grant_minter_role(minter_address);
     // [Effect] Grant Offsetter role to Offsetter contract
     project.grant_offsetter_role(offsetter_address);
+    // [Prank] Stop prank on Project contract
+    stop_prank(CheatTarget::One(project_address));
 
     // [Effect] setup a batch of carbon credits
     let carbon_credits = ICarbonCreditsHandlerDispatcher { contract_address: project_address };
 
     let share: u256 = 10 * CC_DECIMALS_MULTIPLIER / 100; // 10%
-    // [Prank] Simulate production flow, Minter calls Project contract
-    start_prank(CheatTarget::One(project_address), minter_address);
-    buy_utils(minter_address, erc20_address, share);
-    // [Prank] Stop prank on Project contract
-    stop_prank(CheatTarget::One(project_address));
-    let balance_initial = project.balance_of(owner_address, 2025);
+
+    buy_utils_test(owner_address, user_address, minter_address, share);
+
+    let balance_initial = project.balance_of(user_address, 2025);
 
     // [Effect] update Vintage status
     carbon_credits.update_vintage_status(2025, CarbonVintageType::Audited.into());
@@ -313,7 +303,7 @@ fn test_retire_carbon_credits_multiple_retirements() {
     let carbon_retired = offsetter.get_carbon_retired(2025);
     assert(carbon_retired == 100000, 'Error retired carbon credits');
 
-    let balance_final = project.balance_of(owner_address, 2025);
+    let balance_final = project.balance_of(user_address, 2025);
     assert(balance_final == balance_initial - 100000, 'Error balance');
 }
 
@@ -322,6 +312,7 @@ fn test_retire_carbon_credits_multiple_retirements() {
 #[test]
 fn test_retire_list_carbon_credits_valid_inputs() {
     let owner_address: ContractAddress = contract_address_const::<'OWNER'>();
+    let user_address: ContractAddress = contract_address_const::<'USER'>();
     let (project_address, _) = default_setup_and_deploy();
     let (offsetter_address, _) = deploy_offsetter(project_address);
     let (erc20_address, _) = deploy_erc20();
@@ -329,27 +320,25 @@ fn test_retire_list_carbon_credits_valid_inputs() {
 
     // [Prank] Use owner as caller to Project, Offsetter, Minter and ERC20 contracts
     start_prank(CheatTarget::One(project_address), owner_address);
-    start_prank(CheatTarget::One(offsetter_address), owner_address);
-    start_prank(CheatTarget::One(minter_address), owner_address);
-    start_prank(CheatTarget::One(erc20_address), owner_address);
+    start_prank(CheatTarget::One(offsetter_address), user_address);
 
     let project = IProjectDispatcher { contract_address: project_address };
     // [Effect] Grant Minter role to Minter contract
     project.grant_minter_role(minter_address);
     // [Effect] Grant Offsetter role to Offsetter contract
     project.grant_offsetter_role(offsetter_address);
+    // [Prank] Stop prank on Project contract
+    stop_prank(CheatTarget::One(project_address));
 
     // [Effect] setup a batch of carbon credits
     let carbon_credits = ICarbonCreditsHandlerDispatcher { contract_address: project_address };
 
     let share: u256 = 10 * CC_DECIMALS_MULTIPLIER / 100; // 10%
-    // [Prank] Simulate production flow, Minter calls Project contract
-    start_prank(CheatTarget::One(project_address), minter_address);
-    buy_utils(minter_address, erc20_address, share);
-    // [Prank] Stop prank on Project contract
-    stop_prank(CheatTarget::One(project_address));
-    let balance_initial_2025 = project.balance_of(owner_address, 2025);
-    let balance_initial_2026 = project.balance_of(owner_address, 2026);
+
+    buy_utils_test(owner_address, user_address, minter_address, share);
+
+    let balance_initial_2025 = project.balance_of(user_address, 2025);
+    let balance_initial_2026 = project.balance_of(user_address, 2026);
 
     // [Effect] update Vintage status
     carbon_credits.update_vintage_status(2025, CarbonVintageType::Audited.into());
@@ -367,8 +356,8 @@ fn test_retire_list_carbon_credits_valid_inputs() {
     assert(carbon_retired_2025 == 50000, 'Carbon retired value error');
     assert(carbon_retired_2026 == 50000, 'Carbon retired value error');
 
-    let balance_final_2025 = project.balance_of(owner_address, 2025);
-    let balance_final_2026 = project.balance_of(owner_address, 2026);
+    let balance_final_2025 = project.balance_of(user_address, 2025);
+    let balance_final_2026 = project.balance_of(user_address, 2026);
     assert(balance_final_2025 == balance_initial_2025 - 50000, 'Balance error');
     assert(balance_final_2026 == balance_initial_2026 - 50000, 'Balance error');
 }
@@ -376,12 +365,12 @@ fn test_retire_list_carbon_credits_valid_inputs() {
 #[test]
 #[should_panic(expected: ('Inputs cannot be empty',))]
 fn test_retire_list_carbon_credits_empty_inputs() {
-    let owner_address: ContractAddress = contract_address_const::<'OWNER'>();
+    let user_address: ContractAddress = contract_address_const::<'USER'>();
     let (project_address, _) = default_setup_and_deploy();
     let (offsetter_address, _) = deploy_offsetter(project_address);
 
-    // [Prank] Use owner as caller to Offsetter contract
-    start_prank(CheatTarget::One(offsetter_address), owner_address);
+    // [Prank] Use user as caller to Offsetter contract
+    start_prank(CheatTarget::One(offsetter_address), user_address);
 
     // [Effect] try to retire with empty inputs
     let offsetter = IOffsetHandlerDispatcher { contract_address: offsetter_address };
@@ -391,12 +380,12 @@ fn test_retire_list_carbon_credits_empty_inputs() {
 #[test]
 #[should_panic(expected: 'Vintages and Values mismatch')]
 fn test_retire_list_carbon_credits_mismatched_lengths() {
-    let owner_address: ContractAddress = contract_address_const::<'OWNER'>();
+    let user_address: ContractAddress = contract_address_const::<'USER'>();
     let (project_address, _) = default_setup_and_deploy();
     let (offsetter_address, _) = deploy_offsetter(project_address);
 
     // [Prank] Use owner as caller to Offsetter contract
-    start_prank(CheatTarget::One(offsetter_address), owner_address);
+    start_prank(CheatTarget::One(offsetter_address), user_address);
 
     // [Effect] try to retire with mismatched lengths
     let vintages: Span<u256> = array![2025, 2026].span();
@@ -409,6 +398,7 @@ fn test_retire_list_carbon_credits_mismatched_lengths() {
 #[should_panic(expected: ('Vintage status is not audited',))]
 fn test_retire_list_carbon_credits_partial_valid_inputs() {
     let owner_address: ContractAddress = contract_address_const::<'OWNER'>();
+    let user_address: ContractAddress = contract_address_const::<'USER'>();
     let (project_address, _) = default_setup_and_deploy();
     let (offsetter_address, _) = deploy_offsetter(project_address);
     let (erc20_address, _) = deploy_erc20();
@@ -416,24 +406,21 @@ fn test_retire_list_carbon_credits_partial_valid_inputs() {
 
     // [Prank] Use owner as caller to Project, Offsetter, Minter and ERC20 contracts
     start_prank(CheatTarget::One(project_address), owner_address);
-    start_prank(CheatTarget::One(offsetter_address), owner_address);
-    start_prank(CheatTarget::One(minter_address), owner_address);
-    start_prank(CheatTarget::One(erc20_address), owner_address);
+    start_prank(CheatTarget::One(offsetter_address), user_address);
 
     let project = IProjectDispatcher { contract_address: project_address };
     // [Effect] Grant Minter role to Minter contract
     project.grant_minter_role(minter_address);
     // [Effect] Grant Offsetter role to Offsetter contract
     project.grant_offsetter_role(offsetter_address);
+    // [Prank] Stop prank on Project contract
+    stop_prank(CheatTarget::One(project_address));
 
     // [Effect] setup a batch of carbon credits
     let carbon_credits = ICarbonCreditsHandlerDispatcher { contract_address: project_address };
     let share: u256 = 10 * CC_DECIMALS_MULTIPLIER / 100; // 10%
-    // [Prank] Simulate production flow, Minter calls project address
-    start_prank(CheatTarget::One(project_address), minter_address);
-    buy_utils(minter_address, erc20_address, share);
-    // [Prank] Stop prank on Project contract
-    stop_prank(CheatTarget::One(project_address));
+
+    buy_utils_test(owner_address, user_address, minter_address, share);
 
     // [Effect] update Vintage status
     carbon_credits.update_vintage_status(2025, CarbonVintageType::Audited.into());
@@ -449,6 +436,7 @@ fn test_retire_list_carbon_credits_partial_valid_inputs() {
 #[test]
 fn test_retire_list_carbon_credits_multiple_same_vintage() {
     let owner_address: ContractAddress = contract_address_const::<'OWNER'>();
+    let user_address: ContractAddress = contract_address_const::<'USER'>();
     let (project_address, _) = default_setup_and_deploy();
     let (offsetter_address, _) = deploy_offsetter(project_address);
     let (erc20_address, _) = deploy_erc20();
@@ -456,26 +444,24 @@ fn test_retire_list_carbon_credits_multiple_same_vintage() {
 
     // [Prank] Use owner as caller to Project, Offsetter, Minter and ERC20 contracts
     start_prank(CheatTarget::One(project_address), owner_address);
-    start_prank(CheatTarget::One(offsetter_address), owner_address);
-    start_prank(CheatTarget::One(minter_address), owner_address);
-    start_prank(CheatTarget::One(erc20_address), owner_address);
+    start_prank(CheatTarget::One(offsetter_address), user_address);
 
     let project = IProjectDispatcher { contract_address: project_address };
     // [Effect] Grant Minter role to Minter contract
     project.grant_minter_role(minter_address);
     // [Effect] Grant Offsetter role to Offsetter contract
     project.grant_offsetter_role(offsetter_address);
+    // [Prank] Stop prank on Project contract
+    stop_prank(CheatTarget::One(project_address));
 
     // [Effect] setup a batch of carbon credits
     let carbon_credits = ICarbonCreditsHandlerDispatcher { contract_address: project_address };
 
     let share: u256 = 10 * CC_DECIMALS_MULTIPLIER / 100; // 10%
-    // [Prank] Simulate production flow, Minter calls project address
-    start_prank(CheatTarget::One(project_address), minter_address);
-    buy_utils(minter_address, erc20_address, share);
-    // [Prank] Stop prank on Project contract
-    stop_prank(CheatTarget::One(project_address));
-    let initial_balance = project.balance_of(owner_address, 2025);
+
+    buy_utils_test(owner_address, user_address, minter_address, share);
+
+    let initial_balance = project.balance_of(user_address, 2025);
 
     // [Effect] update Vintage status
     carbon_credits.update_vintage_status(2025, CarbonVintageType::Audited.into());
@@ -490,19 +476,19 @@ fn test_retire_list_carbon_credits_multiple_same_vintage() {
     let carbon_retired = offsetter.get_carbon_retired(2025.into());
     assert(carbon_retired == 100000, 'Error Carbon retired');
 
-    let balance_final = project.balance_of(owner_address, 2025);
+    let balance_final = project.balance_of(user_address, 2025);
     assert(balance_final == initial_balance - 100000, 'Error balance');
 }
 /// get_pending_retirement
 
 #[test]
 fn test_get_pending_retirement_no_pending() {
-    let owner_address: ContractAddress = contract_address_const::<'OWNER'>();
+    let user_address: ContractAddress = contract_address_const::<'USER'>();
     let (project_address, _) = default_setup_and_deploy();
     let (offsetter_address, _) = deploy_offsetter(project_address);
 
     // [Prank] Use owner as caller to Offsetter contract
-    start_prank(CheatTarget::One(offsetter_address), owner_address);
+    start_prank(CheatTarget::One(offsetter_address), user_address);
 
     let offsetter = IOffsetHandlerDispatcher { contract_address: offsetter_address };
     let vintage: u256 = 2025.into();
@@ -516,12 +502,12 @@ fn test_get_pending_retirement_no_pending() {
 
 #[test]
 fn test_get_carbon_retired_no_retired() {
-    let owner_address: ContractAddress = contract_address_const::<'OWNER'>();
+    let user_address: ContractAddress = contract_address_const::<'USER'>();
     let (project_address, _) = default_setup_and_deploy();
     let (offsetter_address, _) = deploy_offsetter(project_address);
 
     // [Prank] Use owner as caller to Offsetter contract
-    start_prank(CheatTarget::One(offsetter_address), owner_address);
+    start_prank(CheatTarget::One(offsetter_address), user_address);
 
     let offsetter = IOffsetHandlerDispatcher { contract_address: offsetter_address };
     let vintage: u256 = 2025.into();

--- a/tests/test_offsetter.cairo
+++ b/tests/test_offsetter.cairo
@@ -57,8 +57,7 @@ use carbon_v3::mock::usdcarb::USDCarb;
 // Utils for testing purposes
 
 use super::tests_lib::{
-    default_setup_and_deploy, buy_utils, deploy_offsetter, deploy_erc20, deploy_minter,
-    buy_utils_test
+    default_setup_and_deploy, buy_utils, deploy_offsetter, deploy_erc20, deploy_minter
 };
 
 // Constants
@@ -127,7 +126,7 @@ fn test_offsetter_retire_carbon_credits() {
     let carbon_credits = ICarbonCreditsHandlerDispatcher { contract_address: project_address };
 
     let share: u256 = 10 * CC_DECIMALS_MULTIPLIER / 100; // 10%
-    buy_utils_test(owner_address, user_address, minter_address, share);
+    buy_utils(owner_address, user_address, minter_address, share);
     let initial_balance = project.balance_of(user_address, 2025);
 
     // [Effect] update Vintage status
@@ -169,7 +168,7 @@ fn test_offsetter_wrong_status() {
     // [Effect] setup a batch of carbon credits
     let share = 33 * CC_DECIMALS_MULTIPLIER / 100; // 33%
 
-    buy_utils_test(owner_address, user_address, minter_address, share);
+    buy_utils(owner_address, user_address, minter_address, share);
 
     // [Check] Vintage status is not audited
     let cc_handler = ICarbonCreditsHandlerDispatcher { contract_address: project_address };
@@ -207,7 +206,7 @@ fn test_retire_carbon_credits_insufficient_credits() {
     let carbon_credits = ICarbonCreditsHandlerDispatcher { contract_address: project_address };
 
     let share = 33 * CC_DECIMALS_MULTIPLIER / 100;
-    buy_utils_test(owner_address, user_address, minter_address, share);
+    buy_utils(owner_address, user_address, minter_address, share);
 
     // [Effect] update Vintage status
     carbon_credits.update_vintage_status(2025, CarbonVintageType::Audited.into());
@@ -244,7 +243,7 @@ fn test_retire_carbon_credits_exact_balance() {
 
     let share = 33 * CC_DECIMALS_MULTIPLIER / 100;
 
-    buy_utils_test(owner_address, user_address, minter_address, share);
+    buy_utils(owner_address, user_address, minter_address, share);
 
     let user_balance = project_contract.balance_of(user_address, 2025);
 
@@ -288,7 +287,7 @@ fn test_retire_carbon_credits_multiple_retirements() {
 
     let share: u256 = 10 * CC_DECIMALS_MULTIPLIER / 100; // 10%
 
-    buy_utils_test(owner_address, user_address, minter_address, share);
+    buy_utils(owner_address, user_address, minter_address, share);
 
     let balance_initial = project.balance_of(user_address, 2025);
 
@@ -336,7 +335,7 @@ fn test_retire_list_carbon_credits_valid_inputs() {
 
     let share: u256 = 10 * CC_DECIMALS_MULTIPLIER / 100; // 10%
 
-    buy_utils_test(owner_address, user_address, minter_address, share);
+    buy_utils(owner_address, user_address, minter_address, share);
 
     let balance_initial_2025 = project.balance_of(user_address, 2025);
     let balance_initial_2026 = project.balance_of(user_address, 2026);
@@ -421,7 +420,7 @@ fn test_retire_list_carbon_credits_partial_valid_inputs() {
     let carbon_credits = ICarbonCreditsHandlerDispatcher { contract_address: project_address };
     let share: u256 = 10 * CC_DECIMALS_MULTIPLIER / 100; // 10%
 
-    buy_utils_test(owner_address, user_address, minter_address, share);
+    buy_utils(owner_address, user_address, minter_address, share);
 
     // [Effect] update Vintage status
     carbon_credits.update_vintage_status(2025, CarbonVintageType::Audited.into());
@@ -460,7 +459,7 @@ fn test_retire_list_carbon_credits_multiple_same_vintage() {
 
     let share: u256 = 10 * CC_DECIMALS_MULTIPLIER / 100; // 10%
 
-    buy_utils_test(owner_address, user_address, minter_address, share);
+    buy_utils(owner_address, user_address, minter_address, share);
 
     let initial_balance = project.balance_of(user_address, 2025);
 

--- a/tests/test_offsetter.cairo
+++ b/tests/test_offsetter.cairo
@@ -130,7 +130,9 @@ fn test_offsetter_retire_carbon_credits() {
     let initial_balance = project.balance_of(user_address, 2025);
 
     // [Effect] update Vintage status
+    start_prank(CheatTarget::One(project_address), owner_address);
     carbon_credits.update_vintage_status(2025, CarbonVintageType::Audited.into());
+    stop_prank(CheatTarget::One(project_address));
 
     // [Effect] try to retire carbon credits
     let offsetter = IOffsetHandlerDispatcher { contract_address: offsetter_address };
@@ -209,7 +211,9 @@ fn test_retire_carbon_credits_insufficient_credits() {
     buy_utils(owner_address, user_address, minter_address, share);
 
     // [Effect] update Vintage status
+    start_prank(CheatTarget::One(project_address), owner_address);
     carbon_credits.update_vintage_status(2025, CarbonVintageType::Audited.into());
+    stop_prank(CheatTarget::One(project_address));
 
     // [Effect] try to retire carbon credits
     let offsetter = IOffsetHandlerDispatcher { contract_address: offsetter_address };
@@ -248,7 +252,9 @@ fn test_retire_carbon_credits_exact_balance() {
     let user_balance = project_contract.balance_of(user_address, 2025);
 
     // [Effect] update Vintage status
+    start_prank(CheatTarget::One(project_address), owner_address);
     carbon_credits.update_vintage_status(2025, CarbonVintageType::Audited.into());
+    stop_prank(CheatTarget::One(project_address));
 
     // [Effect] try to retire carbon credits
     let offsetter = IOffsetHandlerDispatcher { contract_address: offsetter_address };
@@ -292,7 +298,9 @@ fn test_retire_carbon_credits_multiple_retirements() {
     let balance_initial = project.balance_of(user_address, 2025);
 
     // [Effect] update Vintage status
+    start_prank(CheatTarget::One(project_address), owner_address);
     carbon_credits.update_vintage_status(2025, CarbonVintageType::Audited.into());
+    stop_prank(CheatTarget::One(project_address));
 
     // [Effect] retire carbon credits multiple times
     let offsetter = IOffsetHandlerDispatcher { contract_address: offsetter_address };
@@ -341,8 +349,10 @@ fn test_retire_list_carbon_credits_valid_inputs() {
     let balance_initial_2026 = project.balance_of(user_address, 2026);
 
     // [Effect] update Vintage status
+    start_prank(CheatTarget::One(project_address), owner_address);
     carbon_credits.update_vintage_status(2025, CarbonVintageType::Audited.into());
     carbon_credits.update_vintage_status(2026, CarbonVintageType::Audited.into());
+    stop_prank(CheatTarget::One(project_address));
 
     // [Effect] retire list of carbon credits
     let vintages: Span<u256> = array![2025.into(), 2026.into()].span();
@@ -423,7 +433,9 @@ fn test_retire_list_carbon_credits_partial_valid_inputs() {
     buy_utils(owner_address, user_address, minter_address, share);
 
     // [Effect] update Vintage status
+    start_prank(CheatTarget::One(project_address), owner_address);
     carbon_credits.update_vintage_status(2025, CarbonVintageType::Audited.into());
+    stop_prank(CheatTarget::One(project_address));
     // Do not update 2026 to keep it invalid
 
     // [Effect] retire list of carbon credits
@@ -464,7 +476,9 @@ fn test_retire_list_carbon_credits_multiple_same_vintage() {
     let initial_balance = project.balance_of(user_address, 2025);
 
     // [Effect] update Vintage status
+    start_prank(CheatTarget::One(project_address), owner_address);
     carbon_credits.update_vintage_status(2025, CarbonVintageType::Audited.into());
+    stop_prank(CheatTarget::One(project_address));
 
     // [Effect] retire list of carbon credits with multiple same vintage
     let vintages: Span<u256> = array![2025.into(), 2025.into()].span();

--- a/tests/test_offsetter.cairo
+++ b/tests/test_offsetter.cairo
@@ -57,7 +57,8 @@ use carbon_v3::mock::usdcarb::USDCarb;
 // Utils for testing purposes
 
 use super::tests_lib::{
-    default_setup_and_deploy, buy_utils, deploy_offsetter, deploy_erc20, deploy_minter, buy_utils_test
+    default_setup_and_deploy, buy_utils, deploy_offsetter, deploy_erc20, deploy_minter,
+    buy_utils_test
 };
 
 // Constants
@@ -167,7 +168,7 @@ fn test_offsetter_wrong_status() {
 
     // [Effect] setup a batch of carbon credits
     let share = 33 * CC_DECIMALS_MULTIPLIER / 100; // 33%
- 
+
     buy_utils_test(owner_address, user_address, minter_address, share);
 
     // [Check] Vintage status is not audited

--- a/tests/test_project.cairo
+++ b/tests/test_project.cairo
@@ -37,7 +37,7 @@ use openzeppelin::token::erc20::interface::{IERC20Dispatcher, IERC20DispatcherTr
 use super::tests_lib::{
     get_mock_times, get_mock_absorptions, equals_with_error, deploy_project, setup_project,
     default_setup_and_deploy, fuzzing_setup, perform_fuzzed_transfer, buy_utils, deploy_erc20,
-    deploy_minter, deploy_offsetter, buy_utils_test, share_to_buy_amount
+    deploy_minter, deploy_offsetter, share_to_buy_amount
 };
 
 #[test]
@@ -224,7 +224,7 @@ fn test_project_offset_with_offsetter_role() {
     let carbon_credits = ICarbonCreditsHandlerDispatcher { contract_address: project_address };
 
     let share: u256 = 10 * CC_DECIMALS_MULTIPLIER / 100; // 10%
-    buy_utils_test(owner_address, user_address, minter_address, share);
+    buy_utils(owner_address, user_address, minter_address, share);
     // [Prank] Stop prank on Project contract
     stop_prank(CheatTarget::One(project_address));
 
@@ -261,7 +261,7 @@ fn test_project_offset_without_offsetter_role() {
     let carbon_credits = ICarbonCreditsHandlerDispatcher { contract_address: project_address };
 
     let share: u256 = 10 * CC_DECIMALS_MULTIPLIER / 100; // 10%
-    buy_utils_test(owner_address, user_address, minter_address, share);
+    buy_utils(owner_address, user_address, minter_address, share);
 
     // [Effect] update Vintage status
     carbon_credits.update_vintage_status(2025, CarbonVintageType::Audited.into());
@@ -299,7 +299,7 @@ fn test_project_batch_offset_with_offsetter_role() {
     let carbon_credits = ICarbonCreditsHandlerDispatcher { contract_address: project_address };
 
     let share: u256 = 10 * CC_DECIMALS_MULTIPLIER / 100; // 10%
-    buy_utils_test(owner_address, user_address, minter_address, share);
+    buy_utils(owner_address, user_address, minter_address, share);
     // [Prank] Stop prank on Project contract
     stop_prank(CheatTarget::One(project_address));
 
@@ -354,7 +354,7 @@ fn test_project_batch_offset_without_offsetter_role() {
 
     let share: u256 = 10 * CC_DECIMALS_MULTIPLIER / 100; // 10%
 
-    buy_utils_test(owner_address, user_address, minter_address, share);
+    buy_utils(owner_address, user_address, minter_address, share);
     // [Prank] Stop prank on Project contract
     stop_prank(CheatTarget::One(project_address));
 
@@ -422,7 +422,7 @@ fn test_project_balance_of() {
     let share = 33 * CC_DECIMALS_MULTIPLIER / 100; // 33% of the total supply
     // [Prank] Stop prank on Project contract
     stop_prank(CheatTarget::One(project_address));
-    buy_utils_test(owner_address, user_address, minter_address, share);
+    buy_utils(owner_address, user_address, minter_address, share);
 
     let supply_vintage_2025 = carbon_credits.get_carbon_vintage(2025).supply;
     let expected_balance = supply_vintage_2025.into() * share / CC_DECIMALS_MULTIPLIER;
@@ -451,7 +451,7 @@ fn test_transfer_without_loss() {
     let share = 33 * CC_DECIMALS_MULTIPLIER / 100; // 33% of the total supply
     // [Prank] Stop prank on Project contract
     stop_prank(CheatTarget::One(project_address));
-    buy_utils_test(owner_address, user_address, minter_address, share);
+    buy_utils(owner_address, user_address, minter_address, share);
     // [Prank] Stop prank on Project contract
     stop_prank(CheatTarget::One(project_address));
     // [Prank] Simulate production flow, user calls Project contract
@@ -515,7 +515,7 @@ fn test_consecutive_transfers_and_rebases(
 
     // [Prank] Stop prank on Project contract
     stop_prank(CheatTarget::One(project_address));
-    buy_utils_test(owner_address, user_address, minter_address, share);
+    buy_utils(owner_address, user_address, minter_address, share);
     let initial_balance = project_contract.balance_of(user_address, 2025);
     // [Prank] Stop prank on Project contract
     stop_prank(CheatTarget::One(project_address));

--- a/tests/test_project.cairo
+++ b/tests/test_project.cairo
@@ -236,7 +236,9 @@ fn test_project_offset_with_offsetter_role() {
     stop_prank(CheatTarget::One(project_address));
 
     // [Effect] update Vintage status
+    start_prank(CheatTarget::One(project_address), owner_address);
     carbon_credits.update_vintage_status(2025, CarbonVintageType::Audited.into());
+    stop_prank(CheatTarget::One(project_address));
 
     // [Prank] Simulate production flow, Offsetter calls Project contract
     start_prank(CheatTarget::One(project_address), offsetter_address);
@@ -271,7 +273,9 @@ fn test_project_offset_without_offsetter_role() {
     buy_utils(owner_address, user_address, minter_address, share);
 
     // [Effect] update Vintage status
+    start_prank(CheatTarget::One(project_address), owner_address);
     carbon_credits.update_vintage_status(2025, CarbonVintageType::Audited.into());
+    stop_prank(CheatTarget::One(project_address));
 
     // [Prank] Simulate error flow, owner calls Project contract
     start_prank(CheatTarget::One(project_address), owner_address);
@@ -311,7 +315,9 @@ fn test_project_batch_offset_with_offsetter_role() {
     stop_prank(CheatTarget::One(project_address));
 
     // [Effect] update Vintage status
+    start_prank(CheatTarget::One(project_address), owner_address);
     carbon_credits.update_vintage_status(2025, CarbonVintageType::Audited.into());
+    stop_prank(CheatTarget::One(project_address));
 
     let share = 100;
     let cc_vintage_years: Span<u256> = carbon_credits.get_vintage_years();
@@ -366,7 +372,9 @@ fn test_project_batch_offset_without_offsetter_role() {
     stop_prank(CheatTarget::One(project_address));
 
     // [Effect] update Vintage status
+    start_prank(CheatTarget::One(project_address), owner_address);
     carbon_credits.update_vintage_status(2025, CarbonVintageType::Audited.into());
+    stop_prank(CheatTarget::One(project_address));
 
     let share = 100;
     let cc_vintage_years: Span<u256> = carbon_credits.get_vintage_years();
@@ -540,7 +548,11 @@ fn test_consecutive_transfers_and_rebases(
     let new_vintage_supply_1 = initial_vintage_supply
         * first_percentage_rebase.try_into().unwrap()
         / 100_000;
+    stop_prank(CheatTarget::One(project_address));
+
+    start_prank(CheatTarget::One(project_address), owner_address);
     absorber.rebase_vintage(2025, new_vintage_supply_1);
+    stop_prank(CheatTarget::One(project_address));
 
     let balance_receiver = project_contract.balance_of(receiver_address, 2025);
     start_prank(CheatTarget::One(project_address), receiver_address);
@@ -548,10 +560,12 @@ fn test_consecutive_transfers_and_rebases(
         .safe_transfer_from(
             receiver_address, user_address, 2025, balance_receiver.into(), array![].span()
         );
+    stop_prank(CheatTarget::One(project_address));
 
     let new_vintage_supply_2 = new_vintage_supply_1
         * second_percentage_rebase.try_into().unwrap()
         / 100_000;
+    start_prank(CheatTarget::One(project_address), owner_address);
     absorber.rebase_vintage(2025, new_vintage_supply_2);
 
     // revert first rebase with the opposite percentage
@@ -565,6 +579,10 @@ fn test_consecutive_transfers_and_rebases(
         * undo_second_percentage_rebase.try_into().unwrap()
         / 100_000;
     absorber.rebase_vintage(2025, new_vintage_supply_4);
+
+    stop_prank(CheatTarget::One(project_address));
+
+    start_prank(CheatTarget::One(project_address), user_address);
 
     let balance_user = project_contract.balance_of(user_address, 2025);
     assert(equals_with_error(balance_user, initial_balance, 10), 'Error final balance owner');

--- a/tests/tests_lib.cairo
+++ b/tests/tests_lib.cairo
@@ -246,19 +246,7 @@ fn fuzzing_setup(cc_supply: u64) -> (ContractAddress, ContractAddress, ContractA
 /// Utility function to buy a share of the total supply.
 /// The share is calculated as a percentage of the total supply. We use share instead of amount
 /// to make it easier to determine the expected values, but in practice the amount is used.
-fn buy_utils(minter_address: ContractAddress, erc20_address: ContractAddress, share: u256) {
-    let minter = IMintDispatcher { contract_address: minter_address };
-    let amount_to_buy = share_to_buy_amount(minter_address, share);
-    let erc20 = IERC20Dispatcher { contract_address: erc20_address };
-
-    erc20.approve(minter_address, amount_to_buy);
-    minter.public_buy(amount_to_buy, false);
-}
-
-/// Utility function to buy a share of the total supply.
-/// The share is calculated as a percentage of the total supply. We use share instead of amount
-/// to make it easier to determine the expected values, but in practice the amount is used.
-fn buy_utils_test(
+fn buy_utils(
     owner_address: ContractAddress,
     caller_address: ContractAddress,
     minter_address: ContractAddress,
@@ -327,7 +315,7 @@ fn perform_fuzzed_transfer(
 
     assert(absorber.is_setup(), 'Error during setup');
 
-    buy_utils_test(owner_address, user_address, minter_address, share);
+    buy_utils(owner_address, user_address, minter_address, share);
 
     start_prank(CheatTarget::One(project_address), user_address);
 

--- a/tests/tests_lib.cairo
+++ b/tests/tests_lib.cairo
@@ -258,7 +258,12 @@ fn buy_utils(minter_address: ContractAddress, erc20_address: ContractAddress, sh
 /// Utility function to buy a share of the total supply.
 /// The share is calculated as a percentage of the total supply. We use share instead of amount
 /// to make it easier to determine the expected values, but in practice the amount is used.
-fn buy_utils_test(owner_address: ContractAddress, caller_address: ContractAddress, minter_address: ContractAddress, share: u256) {
+fn buy_utils_test(
+    owner_address: ContractAddress,
+    caller_address: ContractAddress,
+    minter_address: ContractAddress,
+    share: u256
+) {
     // [Prank] Use caller (usually user) as caller for the Minter contract
     start_prank(CheatTarget::One(minter_address), caller_address);
     let minter = IMintDispatcher { contract_address: minter_address };
@@ -267,13 +272,13 @@ fn buy_utils_test(owner_address: ContractAddress, caller_address: ContractAddres
 
     let amount_to_buy = share_to_buy_amount(minter_address, share);
     // [Prank] Use owner as caller for the ERC20 contract
-    start_prank(CheatTarget::One(erc20_address), owner_address);    // Owner holds initial supply
+    start_prank(CheatTarget::One(erc20_address), owner_address); // Owner holds initial supply
     erc20.transfer(caller_address, amount_to_buy);
-    
+
     // [Prank] Use caller address (usually user) as caller for the ERC20 contract
     start_prank(CheatTarget::One(erc20_address), caller_address);
     erc20.approve(minter_address, amount_to_buy);
-    
+
     // [Prank] Use Minter as caller for the ERC20 contract
     start_prank(CheatTarget::One(erc20_address), minter_address);
     // [Prank] Use caller (usually user) as caller for the Minter contract


### PR DESCRIPTION
closes #84 

- Modify tests_lib with proper `buy_utils` function provided by @julienbrs 
- Change line 349 in `src/components/minter/mint.cairo` due to RBAC problems
- Add user as main caller in proper functions over the testing files: `test_carbon_handler`, `test_offsetter`, `test_mint`, `test_project`