### PR TITLE
Feat: Metadata handler

### DIFF
--- a/src/mock/metadata.cairo
+++ b/src/mock/metadata.cairo
@@ -30,8 +30,9 @@ mod TestMetadata {
 
     #[abi(embed_v0)]
     impl MetadataProviderImpl of IMetadataDescriptor<ContractState> {
-        fn construct_uri(self: @ContractState, token_id: u256) -> ByteArray {
-            "bla bla bla"
+        fn construct_uri(self: @ContractState, token_id: u256) -> Span<felt252> {
+            array!['http://imgur.com/', 'o7a3j', '.png'].span()
+            
         }
     }
 }

--- a/src/mock/metadata.cairo
+++ b/src/mock/metadata.cairo
@@ -32,7 +32,6 @@ mod TestMetadata {
     impl MetadataProviderImpl of IMetadataDescriptor<ContractState> {
         fn construct_uri(self: @ContractState, token_id: u256) -> Span<felt252> {
             array!['http://imgur.com/', 'o7a3j', '.png'].span()
-            
         }
     }
 }

--- a/tests/test_mint.cairo
+++ b/tests/test_mint.cairo
@@ -16,7 +16,6 @@ use snforge_std::{
     ContractClassTrait, test_address, spy_events, EventSpy, CheatSpan, start_cheat_caller_address,
     stop_cheat_caller_address,
 };
-use alexandria_storage::list::{List, ListTrait};
 
 // Components
 

--- a/tests/test_offsetter.cairo
+++ b/tests/test_offsetter.cairo
@@ -26,8 +26,6 @@ use snforge_std::{
     ContractClassTrait, test_address, spy_events, EventSpy, start_cheat_caller_address,
     stop_cheat_caller_address
 };
-use alexandria_storage::list::{List, ListTrait};
-
 // Components
 
 use carbon_v3::components::vintage::interface::{IVintageDispatcher, IVintageDispatcherTrait};

--- a/tests/tests_lib.cairo
+++ b/tests/tests_lib.cairo
@@ -10,7 +10,6 @@ use snforge_std::{
     ContractClassTrait, EventSpy, spy_events, EventSpyTrait, EventSpyAssertionsTrait,
     start_cheat_caller_address, stop_cheat_caller_address
 };
-use alexandria_storage::list::{List, ListTrait};
 
 // Models 
 
@@ -102,11 +101,9 @@ fn share_to_buy_amount(minter_address: ContractAddress, share: u256) -> u256 {
 
 fn deploy_project() -> (ContractAddress, EventSpy) {
     let contract = snf::declare("Project").expect('Declaration failed');
-    let uri = 'uri';
     let starting_year: u64 = 2024;
     let number_of_years: u64 = 20;
     let mut calldata: Array<felt252> = array![
-        uri,
         contract_address_const::<'OWNER'>().into(),
         starting_year.into(),
         number_of_years.into()

--- a/tests/tests_lib.cairo
+++ b/tests/tests_lib.cairo
@@ -104,9 +104,7 @@ fn deploy_project() -> (ContractAddress, EventSpy) {
     let starting_year: u64 = 2024;
     let number_of_years: u64 = 20;
     let mut calldata: Array<felt252> = array![
-        contract_address_const::<'OWNER'>().into(),
-        starting_year.into(),
-        number_of_years.into()
+        contract_address_const::<'OWNER'>().into(), starting_year.into(), number_of_years.into()
     ];
     let (contract_address, _) = contract.deploy(@calldata).expect('Deployment failed');
     let mut spy = spy_events();


### PR DESCRIPTION
Implement PoC Metadata Handler for cpv3
- reuses v2 component provider.
- Metadata is implemented is carbonable/metadata
- Might need to create separate metadata repo for v3