### PR TITLE
Miscellaneous todos

### DIFF
--- a/src/components/minter/mint.cairo
+++ b/src/components/minter/mint.cairo
@@ -67,7 +67,9 @@ mod MintComponent {
     }
 
     #[derive(Drop, starknet::Event)]
-    struct SoldOut {}
+    struct SoldOut {
+        sold_out: bool
+    }
 
     #[derive(Drop, starknet::Event)]
     struct Buy {
@@ -409,7 +411,7 @@ mod MintComponent {
                             PublicSaleClose { old_value: true, new_value: false }
                         )
                     );
-                self.emit(Event::SoldOut(SoldOut {}));
+                self.emit(Event::SoldOut(SoldOut { sold_out: true }));
             };
         }
     }

--- a/src/components/offsetter/interface.cairo
+++ b/src/components/offsetter/interface.cairo
@@ -11,7 +11,7 @@ trait IOffsetHandler<TContractState> {
     /// - If one of the carbon values is not enough or vintage status is not right, 
     /// the function will fail and no carbon will be retired and the function will revert.
     fn retire_list_carbon_credits(
-        ref self: TContractState, vintages: Span<u256>, carbon_values: Span<u256>
+        ref self: TContractState, vintages: Span<u256>, cc_values: Span<u256>
     );
 
     fn claim(ref self: TContractState, amount: u128, timestamp: u128, proof: Array::<felt252>);

--- a/src/components/offsetter/offset_handler.cairo
+++ b/src/components/offsetter/offset_handler.cairo
@@ -139,9 +139,7 @@ mod OffsetComponent {
         }
 
         fn retire_list_carbon_credits(
-            ref self: ComponentState<TContractState>,
-            vintages: Span<u256>,
-            cc_values: Span<u256>
+            ref self: ComponentState<TContractState>, vintages: Span<u256>, cc_values: Span<u256>
         ) {
             // [Check] vintages and carbon values are defined
             assert(vintages.len() > 0, 'Inputs cannot be empty');

--- a/src/components/offsetter/offset_handler.cairo
+++ b/src/components/offsetter/offset_handler.cairo
@@ -141,11 +141,11 @@ mod OffsetComponent {
         fn retire_list_carbon_credits(
             ref self: ComponentState<TContractState>,
             vintages: Span<u256>,
-            carbon_values: Span<u256>
+            cc_values: Span<u256>
         ) {
             // [Check] vintages and carbon values are defined
             assert(vintages.len() > 0, 'Inputs cannot be empty');
-            assert(vintages.len() == carbon_values.len(), 'Vintages and Values mismatch');
+            assert(vintages.len() == cc_values.len(), 'Vintages and Values mismatch');
 
             let mut index: u32 = 0;
             loop {
@@ -154,7 +154,7 @@ mod OffsetComponent {
                     Option::Some(value) => *value.unbox(),
                     Option::None => 0,
                 };
-                let carbon_amount = match carbon_values.get(index) {
+                let carbon_amount = match cc_values.get(index) {
                     Option::Some(value) => *value.unbox(),
                     Option::None => 0,
                 };

--- a/src/contracts/project.cairo
+++ b/src/contracts/project.cairo
@@ -407,7 +407,7 @@ mod Project {
                 .emit(
                     ERC1155Component::Event::TransferSingle(
                         ERC1155Component::TransferSingle {
-                            operator: get_contract_address(),
+                            operator: get_caller_address(),
                             from: Zeroable::zero(),
                             to,
                             id: token_id,
@@ -509,12 +509,11 @@ mod Project {
         ) {
             let to_send = self.cc_to_internal(value, token_id);
             self.erc1155.safe_transfer_from(from, to, token_id, to_send, data);
-            let cc_value = self.internal_to_cc(value, token_id);
             self
                 .emit(
                     ERC1155Component::Event::TransferSingle(
                         ERC1155Component::TransferSingle {
-                            operator: get_caller_address(), from, to, id: token_id, value: cc_value,
+                            operator: get_caller_address(), from, to, id: token_id, value: value,
                         }
                     )
                 );

--- a/src/contracts/project.cairo
+++ b/src/contracts/project.cairo
@@ -25,7 +25,6 @@ trait IExternal<TContractState> {
     fn balance_of_batch(
         self: @TContractState, accounts: Span<ContractAddress>, token_ids: Span<u256>
     ) -> Span<u256>;
-    fn shares_of(self: @TContractState, account: ContractAddress, token_id: u256) -> u256;
     fn safe_transfer_from(
         ref self: TContractState,
         from: ContractAddress,
@@ -319,18 +318,6 @@ mod Project {
             };
 
             batch_balances.span()
-        }
-
-        fn shares_of(self: @ContractState, account: ContractAddress, token_id: u256) -> u256 {
-            let amount_cc_bought = self
-                .erc1155
-                .ERC1155_balances
-                .read((token_id, account)); // expressed in grams
-            let initial_project_supply = self.vintage.get_initial_project_cc_supply();
-            if initial_project_supply == 0 {
-                panic!("Initial project supply is not set");
-            }
-            (amount_cc_bought * CC_DECIMALS_MULTIPLIER) / initial_project_supply.into()
         }
 
         fn safe_transfer_from(

--- a/src/contracts/project.cairo
+++ b/src/contracts/project.cairo
@@ -2,7 +2,7 @@ use starknet::{ContractAddress, ClassHash};
 
 #[starknet::interface]
 trait IExternal<TContractState> {
-    // fn mint(ref self: TContractState, to: ContractAddress, token_id: u256, value: u256);
+    fn mint(ref self: TContractState, to: ContractAddress, token_id: u256, value: u256);
     fn burn(ref self: TContractState, from: ContractAddress, token_id: u256, value: u256);
     fn batch_mint(
         ref self: TContractState, to: ContractAddress, token_ids: Span<u256>, values: Span<u256>
@@ -201,12 +201,12 @@ mod Project {
     // Externals
     #[abi(embed_v0)]
     impl ExternalImpl of super::IExternal<ContractState> {
-        // fn mint(ref self: ContractState, to: ContractAddress, token_id: u256, value: u256) {
-        //     // [Check] Only Minter can mint
-        //     let isMinter = self.accesscontrol.has_role(MINTER_ROLE, get_caller_address());
-        //     assert(isMinter, 'Only Minter can mint');
-        //     self._mint(to, token_id, value);
-        // }
+        fn mint(ref self: ContractState, to: ContractAddress, token_id: u256, value: u256) {
+            // [Check] Only Minter can mint
+            let isMinter = self.accesscontrol.has_role(MINTER_ROLE, get_caller_address());
+            assert(isMinter, 'Only Minter can mint');
+            self._mint(to, token_id, value);
+        }
 
         fn burn(ref self: ContractState, from: ContractAddress, token_id: u256, value: u256) {
             // [Check] Only Offsetter can burn
@@ -229,7 +229,6 @@ mod Project {
             token_ids: Span<u256>,
             values: Span<u256>
         ) {
-            // TODO : Check that the caller is the owner of the value he wnt to burn
             // [Check] Only Offsetter can burn
             let isOffseter = self.accesscontrol.has_role(OFFSETTER_ROLE, get_caller_address());
             assert(isOffseter, 'Only Offsetter can batch burn');
@@ -409,7 +408,7 @@ mod Project {
                     ERC1155Component::Event::TransferSingle(
                         ERC1155Component::TransferSingle {
                             operator: get_contract_address(),
-                            from: get_contract_address(),
+                            from: Zeroable::zero(),
                             to,
                             id: token_id,
                             value: cc_value,

--- a/tests/test_mint.cairo
+++ b/tests/test_mint.cairo
@@ -376,7 +376,7 @@ fn test_is_sold_out() {
     let expected_event_sale_close = MintComponent::Event::PublicSaleClose(
         MintComponent::PublicSaleClose { old_value: true, new_value: false }
     );
-    let expected_event_sold_out = MintComponent::Event::SoldOut(MintComponent::SoldOut {});
+    let expected_event_sold_out = MintComponent::Event::SoldOut(MintComponent::SoldOut { sold_out: true });
     spy.assert_emitted(@array![(minter_address, expected_event_sale_close)]);
     spy.assert_emitted(@array![(minter_address, expected_event_sold_out)]);
 }

--- a/tests/test_mint.cairo
+++ b/tests/test_mint.cairo
@@ -1,7 +1,4 @@
 use snforge_std::cheatcodes::events::EventSpyAssertionsTrait;
-// TODO: 
-// - check if is_setup is needed
-// - refactor project setup into helper function?
 
 // Starknet deps
 

--- a/tests/test_mint.cairo
+++ b/tests/test_mint.cairo
@@ -134,7 +134,8 @@ fn test_public_buy() {
 
     start_cheat_caller_address(erc20_address, owner_address);
     let erc20 = IERC20Dispatcher { contract_address: erc20_address };
-    erc20.transfer(user_address, money_amount);
+    let success = erc20.transfer(user_address, money_amount);
+    assert(success, 'Transfer failed');
 
     start_cheat_caller_address(erc20_address, user_address);
     erc20.approve(minter_address, money_amount);
@@ -228,7 +229,8 @@ fn test_get_remaining_mintable_cc() {
 
     start_cheat_caller_address(erc20_address, owner_address);
     let erc20 = IERC20Dispatcher { contract_address: erc20_address };
-    erc20.transfer(user_address, amount_to_buy);
+    let success = erc20.transfer(user_address, amount_to_buy);
+    assert(success, 'Transfer failed');
 
     start_cheat_caller_address(erc20_address, user_address);
     erc20.approve(minter_address, amount_to_buy);
@@ -248,7 +250,8 @@ fn test_get_remaining_mintable_cc() {
     // Mint all the remaining carbon credits
     let remaining_mintable_cc = minter.get_remaining_mintable_cc();
     start_cheat_caller_address(erc20_address, owner_address);
-    erc20.transfer(user_address, remaining_mintable_cc);
+    let success = erc20.transfer(user_address, remaining_mintable_cc);
+    assert(success, 'Transfer failed');
 
     let remaining_money_to_buy = remaining_mintable_cc
         * minter.get_unit_price()
@@ -325,7 +328,8 @@ fn test_get_min_money_amount_per_tx() {
     let amount_to_buy: u256 = 1000;
     start_cheat_caller_address(erc20_address, owner_address);
     let erc20 = IERC20Dispatcher { contract_address: erc20_address };
-    erc20.transfer(user_address, amount_to_buy);
+    let success = erc20.transfer(user_address, amount_to_buy);
+    assert(success, 'Transfer failed');
 
     start_cheat_caller_address(erc20_address, user_address);
     erc20.approve(minter_address, amount_to_buy);
@@ -381,55 +385,55 @@ fn test_is_sold_out() {
     spy.assert_emitted(@array![(minter_address, expected_event_sold_out)]);
 }
 
-// #[test]
-// #[should_panic(expected: 'Sale is closed')]
-// fn test_public_buy_when_sold_out() {
-//     let owner_address: ContractAddress = contract_address_const::<'OWNER'>();
-//     let user_address: ContractAddress = contract_address_const::<'USER'>();
-//     let project_address = default_setup_and_deploy();
-//     let erc20_address = deploy_erc20();
-//     let minter_address = deploy_minter(project_address, erc20_address);
+#[test]
+#[should_panic(expected: 'Sale is closed')]
+fn test_public_buy_when_sold_out() {
+    let owner_address: ContractAddress = contract_address_const::<'OWNER'>();
+    let user_address: ContractAddress = contract_address_const::<'USER'>();
+    let project_address = default_setup_and_deploy();
+    let erc20_address = deploy_erc20();
+    let minter_address = deploy_minter(project_address, erc20_address);
 
-//     start_cheat_caller_address(project_address, owner_address);
-//     let project_contract = IProjectDispatcher { contract_address: project_address };
-//     project_contract.grant_minter_role(minter_address);
-//     stop_cheat_caller_address(project_address);
+    start_cheat_caller_address(project_address, owner_address);
+    let project_contract = IProjectDispatcher { contract_address: project_address };
+    project_contract.grant_minter_role(minter_address);
+    stop_cheat_caller_address(project_address);
 
-//     let minter = IMintDispatcher { contract_address: minter_address };
-//     let remaining_mintable_cc = minter.get_remaining_mintable_cc();
-//     buy_utils(owner_address, user_address, minter_address, remaining_mintable_cc);
+    let minter = IMintDispatcher { contract_address: minter_address };
+    let remaining_mintable_cc = minter.get_remaining_mintable_cc();
+    buy_utils(owner_address, user_address, minter_address, remaining_mintable_cc);
 
-//     let remaining_cc_after_buying_all = minter.get_remaining_mintable_cc();
-//     assert(remaining_cc_after_buying_all == 0, 'remaining cc wrong value');
+    let remaining_cc_after_buying_all = minter.get_remaining_mintable_cc();
+    assert(remaining_cc_after_buying_all == 0, 'remaining cc wrong value');
 
-//     start_cheat_caller_address(erc20_address, user_address);
-//     buy_utils(owner_address, user_address, minter_address, 1);
-// }
+    start_cheat_caller_address(erc20_address, user_address);
+    buy_utils(owner_address, user_address, minter_address, 1);
+}
 
-// #[test]
-// #[should_panic(expected: 'Minting limit reached')]
-// fn test_public_buy_exceeds_mint_limit() {
-//     let owner_address: ContractAddress = contract_address_const::<'OWNER'>();
-//     let user_address: ContractAddress = contract_address_const::<'USER'>();
-//     let project_address = default_setup_and_deploy();
-//     let erc20_address = deploy_erc20();
-//     let minter_address = deploy_minter(project_address, erc20_address);
+#[test]
+#[should_panic(expected: 'Minting limit reached')]
+fn test_public_buy_exceeds_mint_limit() {
+    let owner_address: ContractAddress = contract_address_const::<'OWNER'>();
+    let user_address: ContractAddress = contract_address_const::<'USER'>();
+    let project_address = default_setup_and_deploy();
+    let erc20_address = deploy_erc20();
+    let minter_address = deploy_minter(project_address, erc20_address);
 
-//     start_cheat_caller_address(project_address, owner_address);
-//     let project_contract = IProjectDispatcher { contract_address: project_address };
-//     project_contract.grant_minter_role(minter_address);
-//     stop_cheat_caller_address(project_address);
+    start_cheat_caller_address(project_address, owner_address);
+    let project_contract = IProjectDispatcher { contract_address: project_address };
+    project_contract.grant_minter_role(minter_address);
+    stop_cheat_caller_address(project_address);
 
-//     let minter = IMintDispatcher { contract_address: minter_address };
-//     let remaining_mintable_cc = minter.get_remaining_mintable_cc();
-//     buy_utils(owner_address, user_address, minter_address, remaining_mintable_cc - 1);
+    let minter = IMintDispatcher { contract_address: minter_address };
+    let remaining_mintable_cc = minter.get_remaining_mintable_cc();
+    buy_utils(owner_address, user_address, minter_address, remaining_mintable_cc - 1);
 
-//     let remaining_cc_after_partial_buy = minter.get_remaining_mintable_cc();
-//     assert(remaining_cc_after_partial_buy == 1, 'remaining cc wrong value');
+    let remaining_cc_after_partial_buy = minter.get_remaining_mintable_cc();
+    assert(remaining_cc_after_partial_buy == 1, 'remaining cc wrong value');
 
-//     start_cheat_caller_address(erc20_address, user_address);
-//     buy_utils(owner_address, user_address, minter_address, 2); // This should cause a panic
-// }
+    start_cheat_caller_address(erc20_address, user_address);
+    buy_utils(owner_address, user_address, minter_address, 2); // This should cause a panic
+}
 
 #[test]
 fn test_set_min_money_amount_per_tx() {
@@ -642,13 +646,15 @@ fn test_withdraw_without_owner_role() {
     start_cheat_caller_address(project_address, owner_address);
     let project = IProjectDispatcher { contract_address: project_address };
     let minter = IMintDispatcher { contract_address: minter_address };
+    let vintage = IVintageDispatcher { contract_address: project_address };
     project.grant_minter_role(minter_address);
 
     start_cheat_caller_address(project_address, minter_address);
-    let share: u256 = 10 * MULTIPLIER_TONS_TO_MGRAMS / 100; // 10%
-    buy_utils(owner_address, owner_address, minter_address, share);
+    let initial_project_supply = vintage.get_initial_project_cc_supply();
+    let cc_to_mint: u256 = initial_project_supply / 10; // 10% of the initial supply
+    buy_utils(owner_address, owner_address, minter_address, cc_to_mint);
     start_cheat_caller_address(erc20_address, user_address);
-    buy_utils(owner_address, user_address, minter_address, share);
+    buy_utils(owner_address, user_address, minter_address, cc_to_mint);
 
     start_cheat_caller_address(minter_address, user_address);
     minter.withdraw();
@@ -675,8 +681,10 @@ fn test_retrieve_amount() {
     let minter = IMintDispatcher { contract_address: minter_address };
     let second_er20 = IERC20Dispatcher { contract_address: second_erc20_address };
 
-    // Transfering incorrect token to minter
-    second_er20.transfer(minter_address, 1000);
+    // Transferring incorrect token to minter
+    let success = second_er20.transfer(minter_address, 1000);
+    assert(success, 'Transfer failed');
+
     start_cheat_caller_address(second_erc20_address, minter_address);
     minter.retrieve_amount(second_erc20_address, owner_address, 1000);
     let balance_after = second_er20.balance_of(owner_address);
@@ -709,8 +717,10 @@ fn test_retrieve_amount_without_owner_role() {
     let minter = IMintDispatcher { contract_address: minter_address };
     let second_er20 = IERC20Dispatcher { contract_address: second_erc20_address };
 
-    // Transfering incorrect token to minter
-    second_er20.transfer(minter_address, 1000);
+    // Transferring incorrect token to minter
+    let success = second_er20.transfer(minter_address, 1000);
+    assert(success, 'Transfer failed');
+
     start_cheat_caller_address(minter_address, user_address);
     start_cheat_caller_address(second_erc20_address, minter_address);
     minter.retrieve_amount(second_erc20_address, user_address, 1000);

--- a/tests/test_mint.cairo
+++ b/tests/test_mint.cairo
@@ -380,7 +380,9 @@ fn test_is_sold_out() {
     let expected_event_sale_close = MintComponent::Event::PublicSaleClose(
         MintComponent::PublicSaleClose { old_value: true, new_value: false }
     );
-    let expected_event_sold_out = MintComponent::Event::SoldOut(MintComponent::SoldOut { sold_out: true });
+    let expected_event_sold_out = MintComponent::Event::SoldOut(
+        MintComponent::SoldOut { sold_out: true }
+    );
     spy.assert_emitted(@array![(minter_address, expected_event_sale_close)]);
     spy.assert_emitted(@array![(minter_address, expected_event_sold_out)]);
 }

--- a/tests/test_project.cairo
+++ b/tests/test_project.cairo
@@ -418,7 +418,7 @@ fn test_transfer_without_loss() {
         .safe_transfer_from(
             user_address, receiver_address, token_id, balance_user_before, array![].span()
         );
-     
+
     let expected_event = helper_expected_transfer_event(
         project_address,
         user_address,
@@ -532,146 +532,92 @@ fn test_consecutive_transfers_and_rebases(
 }
 
 #[test]
-fn fuzz_test_transfer_low_supply_low_amount(
-    raw_supply: u256, raw_share: u256, raw_last_digits_share: u256
-) {
+fn fuzz_test_transfer_low_supply_low_amount(raw_supply: u256, raw_cc_amount: u256) {
     // max supply of a vintage is 10 CC, so 10^9gm of CC
     let max_supply_for_vintage: u256 = 10 * MULTIPLIER_TONS_TO_MGRAMS;
     let percentage_of_balance_to_send = 1; // with 2 digits after the comma, so 0.01%
     perform_fuzzed_transfer(
-        raw_supply,
-        raw_share,
-        raw_last_digits_share,
-        percentage_of_balance_to_send,
-        max_supply_for_vintage
+        raw_supply, raw_cc_amount, percentage_of_balance_to_send, max_supply_for_vintage
     );
 }
 
 #[test]
-fn fuzz_test_transfer_low_supply_medium_amount(
-    raw_supply: u256, raw_share: u256, raw_last_digits_share: u256
-) {
+fn fuzz_test_transfer_low_supply_medium_amount(raw_supply: u256, raw_cc_amount: u256) {
     // max supply of a vintage is 10 CC, so 10^9gm of CC
     let max_supply_for_vintage: u256 = 10 * MULTIPLIER_TONS_TO_MGRAMS;
     let percentage_of_balance_to_send = 300; // with 2 digits after the comma, so 3%
     perform_fuzzed_transfer(
-        raw_supply,
-        raw_share,
-        raw_last_digits_share,
-        percentage_of_balance_to_send,
-        max_supply_for_vintage
+        raw_supply, raw_cc_amount, percentage_of_balance_to_send, max_supply_for_vintage
     );
 }
 
 #[test]
-fn fuzz_test_transfer_low_supply_high_amount(
-    raw_supply: u256, raw_share: u256, raw_last_digits_share: u256
-) {
+fn fuzz_test_transfer_low_supply_high_amount(raw_supply: u256, raw_cc_amount: u256) {
     // max supply of a vintage is 10 CC, so 10^9gm of CC
     let max_supply_for_vintage: u256 = 10 * MULTIPLIER_TONS_TO_MGRAMS;
     let percentage_of_balance_to_send = 10_000; // with 2 digits after the comma, so 100%
     perform_fuzzed_transfer(
-        raw_supply,
-        raw_share,
-        raw_last_digits_share,
-        percentage_of_balance_to_send,
-        max_supply_for_vintage
+        raw_supply, raw_cc_amount, percentage_of_balance_to_send, max_supply_for_vintage
     );
 }
 
 #[test]
-fn fuzz_test_transfer_medium_supply_low_amount(
-    raw_supply: u256, raw_share: u256, raw_last_digits_share: u256
-) {
+fn fuzz_test_transfer_medium_supply_low_amount(raw_supply: u256, raw_cc_amount: u256) {
     // max supply of a vintage is 10k CC in mgrams
     let max_supply_for_vintage: u256 = 10_000 * MULTIPLIER_TONS_TO_MGRAMS;
     let percentage_of_balance_to_send = 1; // with 2 digits after the comma, so 0.01%
     perform_fuzzed_transfer(
-        raw_supply,
-        raw_share,
-        raw_last_digits_share,
-        percentage_of_balance_to_send,
-        max_supply_for_vintage
+        raw_supply, raw_cc_amount, percentage_of_balance_to_send, max_supply_for_vintage
     );
 }
 
 #[test]
-fn fuzz_test_transfer_medium_supply_medium_amount(
-    raw_supply: u256, raw_share: u256, raw_last_digits_share: u256
-) {
+fn fuzz_test_transfer_medium_supply_medium_amount(raw_supply: u256, raw_cc_amount: u256) {
     // max supply of a vintage is 10k CC in mgrams
     let max_supply_for_vintage: u256 = 10_000 * MULTIPLIER_TONS_TO_MGRAMS;
     let percentage_of_balance_to_send = 300; // with 2 digits after the comma, so 3%
     perform_fuzzed_transfer(
-        raw_supply,
-        raw_share,
-        raw_last_digits_share,
-        percentage_of_balance_to_send,
-        max_supply_for_vintage
+        raw_supply, raw_cc_amount, percentage_of_balance_to_send, max_supply_for_vintage
     );
 }
 
 #[test]
-fn fuzz_test_transfer_medium_supply_high_amount(
-    raw_supply: u256, raw_share: u256, raw_last_digits_share: u256
-) {
+fn fuzz_test_transfer_medium_supply_high_amount(raw_supply: u256, raw_cc_amount: u256) {
     // max supply of a vintage is 10k CC in mgrams
     let max_supply_for_vintage: u256 = 10_000 * MULTIPLIER_TONS_TO_MGRAMS;
     let percentage_of_balance_to_send = 10_000; // with 2 digits after the comma, so 100%
     perform_fuzzed_transfer(
-        raw_supply,
-        raw_share,
-        raw_last_digits_share,
-        percentage_of_balance_to_send,
-        max_supply_for_vintage
+        raw_supply, raw_cc_amount, percentage_of_balance_to_send, max_supply_for_vintage
     );
 }
 
 #[test]
-fn fuzz_test_transfer_high_supply_low_amount(
-    raw_supply: u256, raw_share: u256, raw_last_digits_share: u256
-) {
+fn fuzz_test_transfer_high_supply_low_amount(raw_supply: u256, raw_cc_amount: u256) {
     // max supply of a vintage is 10M CC in mgrams
     let max_supply_for_vintage: u256 = 10_000_000 * MULTIPLIER_TONS_TO_MGRAMS;
     let percentage_of_balance_to_send = 1; // with 2 digits after the comma, so 0.01%
     perform_fuzzed_transfer(
-        raw_supply,
-        raw_share,
-        raw_last_digits_share,
-        percentage_of_balance_to_send,
-        max_supply_for_vintage
+        raw_supply, raw_cc_amount, percentage_of_balance_to_send, max_supply_for_vintage
     );
 }
 
 #[test]
-fn fuzz_test_transfer_high_supply_medium_amount(
-    raw_supply: u256, raw_share: u256, raw_last_digits_share: u256
-) {
+fn fuzz_test_transfer_high_supply_medium_amount(raw_supply: u256, raw_cc_amount: u256) {
     // max supply of a vintage is 10M CC in mgrams
     let max_supply_for_vintage: u256 = 10_000_000 * MULTIPLIER_TONS_TO_MGRAMS;
     let percentage_of_balance_to_send = 300; // with 2 digits after the comma, so 3%
     perform_fuzzed_transfer(
-        raw_supply,
-        raw_share,
-        raw_last_digits_share,
-        percentage_of_balance_to_send,
-        max_supply_for_vintage
+        raw_supply, raw_cc_amount, percentage_of_balance_to_send, max_supply_for_vintage
     );
 }
 
 #[test]
-fn fuzz_test_transfer_high_supply_high_amount(
-    raw_supply: u256, raw_share: u256, raw_last_digits_share: u256
-) {
+fn fuzz_test_transfer_high_supply_high_amount(raw_supply: u256, raw_cc_amount: u256) {
     // max supply of a vintage is 10M CC in mgrams
     let max_supply_for_vintage: u256 = 10_000_000 * MULTIPLIER_TONS_TO_MGRAMS;
     let percentage_of_balance_to_send = 10_000; // with 2 digits after the comma, so 100%
     perform_fuzzed_transfer(
-        raw_supply,
-        raw_share,
-        raw_last_digits_share,
-        percentage_of_balance_to_send,
-        max_supply_for_vintage
+        raw_supply, raw_cc_amount, percentage_of_balance_to_send, max_supply_for_vintage
     );
 }
 
@@ -718,17 +664,6 @@ fn test_decimals() {
     let project_decimals = project_contract.decimals();
 
     assert(project_decimals == 8, 'Decimals should be 8');
-}
-
-#[test]
-fn test_shares_of() {
-    let project_address = default_setup_and_deploy();
-    let project_contract = IProjectDispatcher { contract_address: project_address };
-
-    let token_id: u256 = 1;
-    let share_balance = project_contract.shares_of(project_address, token_id);
-
-    assert(share_balance == 0, 'Shares Balance is wrong');
 }
 
 #[test]

--- a/tests/test_project.cairo
+++ b/tests/test_project.cairo
@@ -216,10 +216,14 @@ fn test_project_burn_with_offsetter_role() {
     project.burn(user_address, token_id, internal_value);
 
     let expected_event_1155_transfer_single = helper_expected_transfer_event(
-        project_address, offsetter_address, user_address, Zeroable::zero(), array![token_id].span(), balance
+        project_address,
+        offsetter_address,
+        user_address,
+        Zeroable::zero(),
+        array![token_id].span(),
+        balance
     );
     spy.assert_emitted(@array![(project_address, expected_event_1155_transfer_single)]);
-
 }
 
 #[test]
@@ -280,7 +284,7 @@ fn test_project_batch_burn_with_offsetter_role() {
     stop_cheat_caller_address(project_address);
 
     start_cheat_caller_address(project_address, owner_address);
-    let cc_to_burn = cc_to_mint;    // burn all the minted CC
+    let cc_to_burn = cc_to_mint; // burn all the minted CC
     let num_vintages = vintages.get_num_vintages();
     let mut cc_values: Array<u256> = Default::default();
     let mut tokens: Array<u256> = Default::default();
@@ -304,7 +308,7 @@ fn test_project_batch_burn_with_offsetter_role() {
     let expected_event_1155_transfer = helper_expected_transfer_event(
         project_address, offsetter_address, user_address, Zeroable::zero(), token_ids, cc_to_burn
     );
-    spy.assert_emitted(@array![(project_address, expected_event_1155_transfer)]);   
+    spy.assert_emitted(@array![(project_address, expected_event_1155_transfer)]);
 }
 
 #[test]

--- a/tests/tests_lib.cairo
+++ b/tests/tests_lib.cairo
@@ -435,7 +435,6 @@ fn helper_expected_transfer_event(
 ) -> ERC1155Component::Event {
     let project = IProjectDispatcher { contract_address: project_address };
     if token_ids.len() == 1 {
-        let total_cc_amount = project.internal_to_cc(total_cc_amount, *token_ids.at(0));
         ERC1155Component::Event::TransferSingle(
             ERC1155Component::TransferSingle {
                 operator, from, to, id: *token_ids.at(0), value: total_cc_amount

--- a/tests/tests_lib.cairo
+++ b/tests/tests_lib.cairo
@@ -242,9 +242,10 @@ fn fuzzing_setup(cc_supply: u256) -> (ContractAddress, ContractAddress, Contract
     (project_address, minter_address, erc20_address)
 }
 
-/// Utility function to buy a share of the total supply.
-/// The share is calculated as a percentage of the total supply. We use share instead of amount
-/// to make it easier to determine the expected values, but in practice the amount is used.
+/// Utility function to buy a certain amount of carbon credits
+/// That amount is minted across all vintages
+/// If Bob buys 100 carbon credits, and the vintage 2024 has 10% of the total supply,
+/// Bob will have 10 carbon credits in 2024
 fn buy_utils(
     owner_address: ContractAddress,
     caller_address: ContractAddress,
@@ -288,7 +289,6 @@ fn buy_utils(
 fn perform_fuzzed_transfer(
     raw_supply: u256,
     raw_cc_amount: u256,
-    raw_last_digits_share: u256,
     percentage_of_balance_to_send: u256,
     max_supply_for_vintage: u256
 ) {

--- a/tests/tests_lib.cairo
+++ b/tests/tests_lib.cairo
@@ -263,7 +263,8 @@ fn buy_utils(
     // [Prank] Use owner as caller for the ERC20 contract
     start_cheat_caller_address(erc20_address, owner_address); // Owner holds initial supply
 
-    erc20.transfer(caller_address, money_to_buy);
+    let success = erc20.transfer(caller_address, money_to_buy);
+    assert(success, 'Transfer failed');
 
     // [Prank] Use caller address (usually user) as caller for the ERC20 contract
     start_cheat_caller_address(erc20_address, caller_address);


### PR DESCRIPTION
**Description of changes**:
---
- Reintroduced the `mint` function in project.cairo and its associated tests. While not expected to be used in production (since `public_buy` relies on `batch_mint`), it is available for completeness.
- Corrected event emission handling in tests; specifically, addressed inconsistencies in the `operator` variable due to legacy 1155 code.
- Updated various minor naming.
- Modified the `SoldOut` event to now include a boolean value.
- Added assertions for successful transfers in tests.
- Completely removed the outdated share logic, along with all related references and tests.