### PR TITLE
🐛 minimum money amount

### DIFF
--- a/src/components/minter/mint.cairo
+++ b/src/components/minter/mint.cairo
@@ -2,6 +2,7 @@
 mod MintComponent {
     // Starknet imports
 
+    use openzeppelin::token::erc20::interface::ERC20ABIDispatcherTrait;
     use starknet::ContractAddress;
     use starknet::{get_caller_address, get_contract_address, get_block_timestamp};
 
@@ -352,9 +353,8 @@ mod MintComponent {
             let unit_price = self.Mint_unit_price.read();
             // If user wants to buy 1 carbon credit, the input should be 1*MULTIPLIER_TONS_TO_MGRAMS
             let money_amount = cc_amount * unit_price / MULTIPLIER_TONS_TO_MGRAMS;
-
-            let min_money_amount_per_tx = self.Mint_min_money_amount_per_tx.read();
-            assert(money_amount >= min_money_amount_per_tx, 'Value too low');
+            // let min_money_amount_per_tx = 1;
+            assert(money_amount >= 1, 'Value too low');
 
             let remaining_mintable_cc = self.Mint_remaining_mintable_cc.read();
             assert(remaining_mintable_cc >= cc_amount, 'Minting limit reached');

--- a/tests/test_mint.cairo
+++ b/tests/test_mint.cairo
@@ -1,3 +1,4 @@
+use openzeppelin::token::erc20::interface::ERC20ABIDispatcherTrait;
 use snforge_std::cheatcodes::events::EventSpyAssertionsTrait;
 
 // Starknet deps
@@ -169,6 +170,92 @@ fn test_public_buy() {
 
     let balance_user_after = helper_sum_balance(project_address, user_address);
     assert(equals_with_error(balance_user_after, cc_to_buy, 100), 'balance should be the same');
+}
+
+
+#[test]
+fn test_minimal_buy() {
+    let owner_address: ContractAddress = contract_address_const::<'OWNER'>();
+    let user_address: ContractAddress = contract_address_const::<'USER'>();
+    let project_address = default_setup_and_deploy();
+    let erc20_address = deploy_erc20();
+    let minter_address = deploy_minter(project_address, erc20_address);
+
+    start_cheat_caller_address(project_address, owner_address);
+    let project_contract = IProjectDispatcher { contract_address: project_address };
+    project_contract.grant_minter_role(minter_address);
+
+    stop_cheat_caller_address(project_address);
+    let minter = IMintDispatcher { contract_address: minter_address };
+    let erc20 = IERC20Dispatcher { contract_address: erc20_address };
+    let cc_to_buy: u256 = MULTIPLIER_TONS_TO_MGRAMS / minter.get_unit_price() + 1;
+    let money_amount = cc_to_buy * minter.get_unit_price() / MULTIPLIER_TONS_TO_MGRAMS;
+
+    start_cheat_caller_address(erc20_address, owner_address);
+    let success = erc20.transfer(user_address, money_amount);
+    assert(success, 'Transfer failed');
+
+    start_cheat_caller_address(erc20_address, user_address);
+    erc20.approve(minter_address, money_amount);
+
+    start_cheat_caller_address(minter_address, user_address);
+    start_cheat_caller_address(erc20_address, minter_address);
+
+    let mut spy = spy_events();
+    minter.public_buy(cc_to_buy);
+
+    let balance = helper_sum_balance(project_address, user_address);
+    assert(equals_with_error(balance, cc_to_buy, 100), 'balance should be the same');
+
+    let token_ids = helper_get_token_ids(project_address);
+
+    let expected_events = helper_expected_transfer_single_events(
+        project_address, minter_address, Zeroable::zero(), user_address, token_ids, cc_to_buy
+    );
+    spy.assert_emitted(@expected_events);
+}
+
+#[test]
+#[should_panic(expected: 'Value too low')]
+fn test_minimal_buy_error() {
+    let owner_address: ContractAddress = contract_address_const::<'OWNER'>();
+    let user_address: ContractAddress = contract_address_const::<'USER'>();
+    let project_address = default_setup_and_deploy();
+    let erc20_address = deploy_erc20();
+    let minter_address = deploy_minter(project_address, erc20_address);
+
+    start_cheat_caller_address(project_address, owner_address);
+    let project_contract = IProjectDispatcher { contract_address: project_address };
+    project_contract.grant_minter_role(minter_address);
+
+    stop_cheat_caller_address(project_address);
+    let minter = IMintDispatcher { contract_address: minter_address };
+    let erc20 = IERC20Dispatcher { contract_address: erc20_address };
+    let cc_to_buy: u256 = MULTIPLIER_TONS_TO_MGRAMS / minter.get_unit_price();
+    let money_amount = cc_to_buy * minter.get_unit_price() / MULTIPLIER_TONS_TO_MGRAMS;
+
+    start_cheat_caller_address(erc20_address, owner_address);
+    let success = erc20.transfer(user_address, money_amount);
+    assert(success, 'Transfer failed');
+
+    start_cheat_caller_address(erc20_address, user_address);
+    erc20.approve(minter_address, money_amount);
+
+    start_cheat_caller_address(minter_address, user_address);
+    start_cheat_caller_address(erc20_address, minter_address);
+
+    let mut spy = spy_events();
+    minter.public_buy(cc_to_buy);
+
+    let balance = helper_sum_balance(project_address, user_address);
+    assert(equals_with_error(balance, cc_to_buy, 100), 'balance should be the same');
+
+    let token_ids = helper_get_token_ids(project_address);
+
+    let expected_events = helper_expected_transfer_single_events(
+        project_address, minter_address, Zeroable::zero(), user_address, token_ids, cc_to_buy
+    );
+    spy.assert_emitted(@expected_events);
 }
 
 // set_max_mintable_cc
@@ -535,7 +622,7 @@ fn test_set_unit_price_without_owner_role() {
     let minter_address = deploy_minter(project_address, erc20_address);
 
     let minter = IMintDispatcher { contract_address: minter_address };
-    let price: u256 = 100;
+    let price: u256 = 100000000;
     minter.set_unit_price(price);
 }
 
@@ -550,11 +637,11 @@ fn test_set_unit_price_with_owner_role() {
     start_cheat_caller_address(minter_address, owner_address);
 
     let minter = IMintDispatcher { contract_address: minter_address };
-    let price: u256 = 100;
+    let price: u256 = 100000000; // $100
     minter.set_unit_price(price);
 
     let expected_event = MintComponent::Event::UnitPriceUpdated(
-        MintComponent::UnitPriceUpdated { old_price: 11, new_price: price }
+        MintComponent::UnitPriceUpdated { old_price: 11000000, new_price: price }
     );
     spy.assert_emitted(@array![(minter_address, expected_event)]);
 }
@@ -572,7 +659,7 @@ fn test_set_unit_price_to_zero_panic() {
 
     // Ensure the unit price is not set initially
     let unit_price = minter.get_unit_price();
-    assert(unit_price == 11, 'unit price should be 11');
+    assert(unit_price == 11000000, 'unit price should be 11000000');
 
     // Set the unit price to 0 and it should panic
     let new_unit_price: u256 = 0;
@@ -593,11 +680,11 @@ fn test_get_unit_price() {
     let minter = IMintDispatcher { contract_address: minter_address };
 
     let unit_price = minter.get_unit_price();
-    assert(unit_price == 11, 'unit price should be 11');
+    assert(unit_price == 11000000, 'unit price should be 11000000');
     stop_cheat_caller_address(minter_address);
 
     start_cheat_caller_address(minter_address, owner_address);
-    let new_unit_price: u256 = 1000;
+    let new_unit_price: u256 = 100000000;
     start_cheat_caller_address(minter_address, owner_address);
     minter.set_unit_price(new_unit_price);
     stop_cheat_caller_address(minter_address);

--- a/tests/test_mint.cairo
+++ b/tests/test_mint.cairo
@@ -536,7 +536,7 @@ fn test_public_buy_exceeds_mint_limit() {
     assert(remaining_cc_after_partial_buy == 1, 'remaining cc wrong value');
 
     start_cheat_caller_address(erc20_address, user_address);
-    buy_utils(owner_address, user_address, minter_address, 2); // This should cause a panic
+    buy_utils(owner_address, user_address, minter_address, 200); // This should cause a panic
 }
 
 #[test]

--- a/tests/tests_lib.cairo
+++ b/tests/tests_lib.cairo
@@ -164,7 +164,7 @@ fn deploy_minter(
     let public_sale: bool = true;
     let low: felt252 = DEFAULT_REMAINING_MINTABLE_CC.low.into();
     let high: felt252 = DEFAULT_REMAINING_MINTABLE_CC.high.into();
-    let unit_price: felt252 = 11;
+    let unit_price: felt252 = 11000000; // $11, 6 decimals like USDC
     let mut calldata: Array<felt252> = array![
         project_address.into(),
         payment_address.into(),
@@ -189,7 +189,7 @@ fn deploy_minter_specific_max_mintable(
     let high: felt252 = max_mintable_cc.high.into();
     start_cheat_caller_address(project_address, owner);
     let public_sale: bool = true;
-    let unit_price: felt252 = 11;
+    let unit_price: felt252 = 11000000;
     let mut calldata: Array<felt252> = array![
         project_address.into(),
         payment_address.into(),


### PR DESCRIPTION
closes #137 
Either we make sure the minimal amount to pay is > 0 (to avoid any rounding errors that could lead to buy CC with $0), or we put an arbitrary min amount to buy (for example 1 cents)