### PR TITLE
add-carbon-offset-to-claim-and-tests

### DIFF
--- a/src/components/offsetter/interface.cairo
+++ b/src/components/offsetter/interface.cairo
@@ -3,7 +3,6 @@ use carbon_v3::models::carbon_vintage::CarbonVintage;
 
 #[starknet::interface]
 trait IOffsetHandler<TContractState> {
-
     /// Retire carbon credits from one vintage of carbon credits.
     fn retire_carbon_credits(ref self: TContractState, token_id: u256, cc_amount: u256);
 
@@ -16,21 +15,22 @@ trait IOffsetHandler<TContractState> {
     );
 
     fn confirm_for_merkle_tree(
-        ref self: TContractState, from: ContractAddress, amount: u128, timestamp: u128, id: u128, proof: Array::<felt252>
+        ref self: TContractState,
+        from: ContractAddress,
+        amount: u128,
+        timestamp: u128,
+        id: u128,
+        proof: Array::<felt252>
     ) -> bool;
 
     fn confirm_offset(
         ref self: TContractState, amount: u128, timestamp: u128, id: u128, proof: Array::<felt252>
     );
 
-    fn get_allocation_id(
-        self: @TContractState, from: ContractAddress
-    ) -> u256;
+    fn get_allocation_id(self: @TContractState, from: ContractAddress) -> u256;
 
 
-    fn get_retirement(
-        self: @TContractState, token_id: u256, from: ContractAddress
-    ) -> u256;
+    fn get_retirement(self: @TContractState, token_id: u256, from: ContractAddress) -> u256;
 
     /// Get the pending retirement of a vintage for the caller address.
     fn get_pending_retirement(

--- a/src/components/offsetter/interface.cairo
+++ b/src/components/offsetter/interface.cairo
@@ -3,6 +3,7 @@ use carbon_v3::models::carbon_vintage::CarbonVintage;
 
 #[starknet::interface]
 trait IOffsetHandler<TContractState> {
+
     /// Retire carbon credits from one vintage of carbon credits.
     fn retire_carbon_credits(ref self: TContractState, token_id: u256, cc_amount: u256);
 
@@ -14,9 +15,22 @@ trait IOffsetHandler<TContractState> {
         ref self: TContractState, token_ids: Span<u256>, cc_amounts: Span<u256>
     );
 
-    fn claim(
+    fn confirm_for_merkle_tree(
+        ref self: TContractState, from: ContractAddress, amount: u128, timestamp: u128, id: u128, proof: Array::<felt252>
+    ) -> bool;
+
+    fn confirm_offset(
         ref self: TContractState, amount: u128, timestamp: u128, id: u128, proof: Array::<felt252>
     );
+
+    fn get_allocation_id(
+        self: @TContractState, from: ContractAddress
+    ) -> u256;
+
+
+    fn get_retirement(
+        self: @TContractState, token_id: u256, from: ContractAddress
+    ) -> u256;
 
     /// Get the pending retirement of a vintage for the caller address.
     fn get_pending_retirement(

--- a/src/components/offsetter/interface.cairo
+++ b/src/components/offsetter/interface.cairo
@@ -13,7 +13,7 @@ trait IOffsetHandler<TContractState> {
     fn retire_list_carbon_credits(
         ref self: TContractState, token_ids: Span<u256>, cc_amounts: Span<u256>
     );
-    
+
     ///Verify and validate the proof on the Merkle tree side to confirm the offset.
     fn confirm_for_merkle_tree(
         ref self: TContractState,

--- a/src/components/offsetter/interface.cairo
+++ b/src/components/offsetter/interface.cairo
@@ -13,7 +13,8 @@ trait IOffsetHandler<TContractState> {
     fn retire_list_carbon_credits(
         ref self: TContractState, token_ids: Span<u256>, cc_amounts: Span<u256>
     );
-
+    
+    ///Verify and validate the proof on the Merkle tree side to confirm the offset.
     fn confirm_for_merkle_tree(
         ref self: TContractState,
         from: ContractAddress,
@@ -23,6 +24,7 @@ trait IOffsetHandler<TContractState> {
         proof: Array::<felt252>
     ) -> bool;
 
+    ///Verify on the business logic side, confirm on the Merkle tree side, and perform the offset action.
     fn confirm_offset(
         ref self: TContractState, amount: u128, timestamp: u128, id: u128, proof: Array::<felt252>
     );

--- a/src/components/offsetter/offset_handler.cairo
+++ b/src/components/offsetter/offset_handler.cairo
@@ -177,14 +177,14 @@ mod OffsetComponent {
             let root_computed = merkle_tree.compute_root(leaf, proof.span());
 
             let stored_root = self.Offsetter_merkle_root.read();
-            if root_computed != stored_root{
+            if root_computed != stored_root {
                 assert(root_computed == stored_root, 'Invalid proof');
                 return false;
             }
-            
+
             return true;
         }
-        
+
         fn confirm_offset(
             ref self: ComponentState<TContractState>,
             amount: u128,
@@ -217,12 +217,9 @@ mod OffsetComponent {
                         claimee: claimee, amount: amount, timestamp: timestamp, id: id
                     }
                 );
-
         }
 
-        fn get_allocation_id(
-            self: @ComponentState<TContractState>, from: ContractAddress
-        ) -> u256 {
+        fn get_allocation_id(self: @ComponentState<TContractState>, from: ContractAddress) -> u256 {
             self.Offsetter_allocation_id.read(from)
         }
 

--- a/src/components/offsetter/offset_handler.cairo
+++ b/src/components/offsetter/offset_handler.cairo
@@ -199,7 +199,7 @@ mod OffsetComponent {
             assert(!claimed, 'Already claimed');
 
             // [Verify if the merkle tree claim is possible]
-            assert!(self.confirm_for_merkle_tree(claimee, amount, timestamp, id, proof));
+            assert(self.confirm_for_merkle_tree(claimee, amount, timestamp, id, proof), 'Invalid proof');
 
             //If everything is correct, we offset the carbon credits
             self._offset_carbon_credit(claimee, 1, amount.into());

--- a/src/components/offsetter/offset_handler.cairo
+++ b/src/components/offsetter/offset_handler.cairo
@@ -199,7 +199,9 @@ mod OffsetComponent {
             assert(!claimed, 'Already claimed');
 
             // [Verify if the merkle tree claim is possible]
-            assert(self.confirm_for_merkle_tree(claimee, amount, timestamp, id, proof), 'Invalid proof');
+            assert(
+                self.confirm_for_merkle_tree(claimee, amount, timestamp, id, proof), 'Invalid proof'
+            );
 
             //If everything is correct, we offset the carbon credits
             self._offset_carbon_credit(claimee, 1, amount.into());

--- a/tests/test_merkle_tree.cairo
+++ b/tests/test_merkle_tree.cairo
@@ -66,34 +66,31 @@ fn test_bob_claims_single_allocation() {
     start_cheat_caller_address(offsetter_address, bob_address);
     assert_eq!(contract.get_merkle_root(), root);
 
-    assert!(!contract.check_claimed(bob_address, timestamp, amount, id));
-
-    start_cheat_caller_address(offsetter_address, bob_address);
-    contract.claim(amount, timestamp, id, proof);
-
-    assert!(contract.check_claimed(bob_address, timestamp, amount, id));
+    //start_cheat_caller_address(offsetter_address, bob_address);
+    assert!(contract.confirm_for_merkle_tree(bob_address, amount, timestamp, id, proof));
 }
 
-#[test]
-#[should_panic(expected: 'Already claimed')]
-fn test_bob_claims_twice() {
-    /// Test that trying to claim the same allocation twice results in a panic.
-    let owner_address = contract_address_const::<'OWNER'>();
-    let (root, bob_address, amount, timestamp, id, proof) = get_bob_first_wave_allocation();
-    let project_address = default_setup_and_deploy();
-    let offsetter_address = deploy_offsetter(project_address);
-    let contract = IOffsetHandlerDispatcher { contract_address: offsetter_address };
-
-    start_cheat_caller_address(offsetter_address, owner_address);
-    contract.set_merkle_root(root);
-    assert!(!contract.check_claimed(bob_address, timestamp, amount, id));
-
-    start_cheat_caller_address(offsetter_address, bob_address);
-    contract.claim(amount, timestamp, id, proof.clone());
-    assert!(contract.check_claimed(bob_address, timestamp, amount, id));
-
-    contract.claim(amount, timestamp, id, proof);
-}
+///Keep this test for the confirm_offset tests.
+//#[test]
+//#[should_panic(expected: 'Already claimed')]
+//fn test_bob_claims_twice() {
+//    /// Test that trying to confirm_for_merkle_tree the same allocation twice results in a panic.
+//    let owner_address = contract_address_const::<'OWNER'>();
+//    let (root, bob_address, amount, timestamp, id, proof) = get_bob_first_wave_allocation();
+//    let project_address = default_setup_and_deploy();
+//    let offsetter_address = deploy_offsetter(project_address);
+//    let contract = IOffsetHandlerDispatcher { contract_address: offsetter_address };
+//
+//    start_cheat_caller_address(offsetter_address, owner_address);
+//    contract.set_merkle_root(root);
+//    assert!(!contract.check_claimed(bob_address, timestamp, amount, id));
+//
+//    //start_cheat_caller_address(offsetter_address, bob_address);
+//    contract.confirm_for_merkle_tree(bob_address, amount, timestamp, id, proof.clone());
+//    assert!(contract.check_claimed(bob_address, timestamp, amount, id));
+//
+//    contract.confirm_for_merkle_tree(bob_address, amount, timestamp, id, proof);
+//}
 
 #[test]
 #[should_panic(expected: 'Invalid proof')]
@@ -109,8 +106,8 @@ fn test_claim_with_invalid_address() {
     let invalid_address = contract_address_const::<'DUMMY'>();
     assert!(!contract.check_claimed(invalid_address, timestamp, amount, id));
 
-    start_cheat_caller_address(offsetter_address, invalid_address);
-    contract.claim(amount, timestamp, id, proof);
+    //start_cheat_caller_address(offsetter_address, invalid_address);
+    assert!(!contract.confirm_for_merkle_tree(invalid_address, amount, timestamp, id, proof));
 }
 
 #[test]
@@ -127,8 +124,8 @@ fn test_claim_with_invalid_amount() {
     let invalid_amount = 0;
     assert!(!contract.check_claimed(bob_address, timestamp, invalid_amount, id));
 
-    start_cheat_caller_address(offsetter_address, bob_address);
-    contract.claim(invalid_amount, timestamp, id, proof);
+    //start_cheat_caller_address(offsetter_address, bob_address);
+    assert!(!contract.confirm_for_merkle_tree(bob_address, invalid_amount, timestamp, id, proof));
 }
 
 #[test]
@@ -145,8 +142,8 @@ fn test_claim_with_invalid_timestamp() {
     let invalid_timestamp = 0;
     assert!(!contract.check_claimed(bob_address, invalid_timestamp, amount, id));
 
-    start_cheat_caller_address(offsetter_address, bob_address);
-    contract.claim(amount, invalid_timestamp, id, proof);
+    //start_cheat_caller_address(offsetter_address, bob_address);
+    assert!(!contract.confirm_for_merkle_tree(bob_address, amount, invalid_timestamp, id, proof));
 }
 
 #[test]
@@ -163,33 +160,34 @@ fn test_claim_with_invalid_proof() {
     let invalid_proof: Array<felt252> = array![0x123, 0x1];
     assert!(!contract.check_claimed(bob_address, timestamp, amount, id));
 
-    start_cheat_caller_address(offsetter_address, bob_address);
-    contract.claim(amount, timestamp, id, invalid_proof);
+    //start_cheat_caller_address(offsetter_address, bob_address);
+    assert!(!contract.confirm_for_merkle_tree(bob_address, amount, timestamp, id, invalid_proof));
 }
 
-#[test]
-fn test_event_emission_on_claim() {
-    let (root, bob_address, amount, timestamp, id, proof) = get_bob_first_wave_allocation();
-    let owner_address = contract_address_const::<'OWNER'>();
-    let project_address = default_setup_and_deploy();
-    let offsetter_address = deploy_offsetter(project_address);
-    let contract = IOffsetHandlerDispatcher { contract_address: offsetter_address };
-
-    start_cheat_caller_address(offsetter_address, owner_address);
-    contract.set_merkle_root(root);
-    assert!(!contract.check_claimed(bob_address, timestamp, amount, id));
-
-    let mut spy = spy_events();
-    start_cheat_caller_address(offsetter_address, bob_address);
-    contract.claim(amount, timestamp, id, proof);
-
-    let expected_event = OffsetComponent::Event::AllocationClaimed(
-        OffsetComponent::AllocationClaimed { claimee: bob_address, amount, timestamp, id }
-    );
-    spy.assert_emitted(@array![(offsetter_address, expected_event)]);
-
-    assert!(contract.check_claimed(bob_address, timestamp, amount, id));
-}
+///Keep this test for the confirm_offset tests.
+//#[test]
+//fn test_event_emission_on_claim() {
+//    let (root, bob_address, amount, timestamp, id, proof) = get_bob_first_wave_allocation();
+//    let owner_address = contract_address_const::<'OWNER'>();
+//    let project_address = default_setup_and_deploy();
+//    let offsetter_address = deploy_offsetter(project_address);
+//    let contract = IOffsetHandlerDispatcher { contract_address: offsetter_address };
+//
+//    start_cheat_caller_address(offsetter_address, owner_address);
+//    contract.set_merkle_root(root);
+//    assert!(!contract.check_claimed(bob_address, timestamp, amount, id));
+//
+//    let mut spy = spy_events();
+//    //start_cheat_caller_address(offsetter_address, bob_address);
+//    contract.confirm_for_merkle_tree(bob_address, amount, timestamp, id, proof);
+//
+//    let expected_event = OffsetComponent::Event::AllocationClaimed(
+//        OffsetComponent::AllocationClaimed { claimee: bob_address, amount, timestamp, id }
+//    );
+//    spy.assert_emitted(@array![(offsetter_address, expected_event)]);
+//
+//    assert!(contract.check_claimed(bob_address, timestamp, amount, id));
+//}
 
 #[test]
 fn test_claim_after_root_update() {
@@ -208,14 +206,13 @@ fn test_claim_after_root_update() {
     contract.set_merkle_root(new_root);
     assert!(!contract.check_claimed(bob_address, timestamp, amount, id));
 
-    start_cheat_caller_address(offsetter_address, bob_address);
-    contract.claim(amount, timestamp, id, new_proof);
-    assert!(contract.check_claimed(bob_address, timestamp, amount, id));
+    //start_cheat_caller_address(offsetter_address, bob_address);
+    assert!(contract.confirm_for_merkle_tree(bob_address, amount, timestamp, id, new_proof));
 }
 
 #[test]
 fn test_alice_claims_in_second_wave() {
-    /// Test that Bob can claim his allocation from the first wave and Alice can claim her allocation from the second wave.
+    /// Test that Bob can confirm his allocation from the first wave and Alice can confirm her allocation from the second wave.
     let (root, bob_address, amount, timestamp, id, proof) = get_bob_first_wave_allocation();
     let owner_address = contract_address_const::<'OWNER'>();
     let project_address = default_setup_and_deploy();
@@ -226,15 +223,8 @@ fn test_alice_claims_in_second_wave() {
     contract.set_merkle_root(root);
     assert!(!contract.check_claimed(bob_address, timestamp, amount, id));
 
-    let mut spy = spy_events();
-    start_cheat_caller_address(offsetter_address, bob_address);
-    contract.claim(amount, timestamp, id, proof);
-
-    let expected_event = OffsetComponent::Event::AllocationClaimed(
-        OffsetComponent::AllocationClaimed { claimee: bob_address, amount, timestamp, id }
-    );
-    spy.assert_emitted(@array![(offsetter_address, expected_event)]);
-    assert!(contract.check_claimed(bob_address, timestamp, amount, id));
+    //start_cheat_caller_address(offsetter_address, bob_address);
+    assert!(contract.confirm_for_merkle_tree(bob_address, amount, timestamp, id, proof));
 
     let (new_root, alice_address, amount, timestamp, id, proof) =
         get_alice_second_wave_allocation();
@@ -242,14 +232,13 @@ fn test_alice_claims_in_second_wave() {
     contract.set_merkle_root(new_root);
     assert!(!contract.check_claimed(alice_address, timestamp, amount, id));
 
-    start_cheat_caller_address(offsetter_address, alice_address);
-    contract.claim(amount, timestamp, id, proof);
-    assert!(contract.check_claimed(alice_address, timestamp, amount, id));
+    //start_cheat_caller_address(offsetter_address, alice_address);
+    assert!(contract.confirm_for_merkle_tree(alice_address, amount, timestamp, id, proof));
 }
 
 #[test]
 fn test_john_claims_multiple_allocations() {
-    /// Test that John can claim two of his three allocations from the first wave, and the remaining one from the second wave.
+    /// Test that John can confirm_for_merkle_tree two of his three allocations from the first wave, and the remaining one from the second wave.
     let (
         root,
         new_root,
@@ -284,18 +273,13 @@ fn test_john_claims_multiple_allocations() {
     assert!(!contract.check_claimed(john_address, timestamp2, amount2, id_2));
     assert!(!contract.check_claimed(john_address, timestamp3, amount3, id_3));
 
-    start_cheat_caller_address(offsetter_address, john_address);
-    contract.claim(amount1, timestamp1, id_1, proof1);
-    contract.claim(amount2, timestamp2, id_2, proof2);
-    assert!(contract.check_claimed(john_address, timestamp1, amount1, id_1));
-    assert!(contract.check_claimed(john_address, timestamp2, amount2, id_2));
-    assert!(!contract.check_claimed(john_address, timestamp3, amount3, id_3));
+    //start_cheat_caller_address(offsetter_address, john_address);
+    assert!(contract.confirm_for_merkle_tree(john_address, amount1, timestamp1, id_1, proof1));
+    assert!(contract.confirm_for_merkle_tree(john_address, amount2, timestamp2, id_2, proof2));
 
     start_cheat_caller_address(offsetter_address, owner_address);
     contract.set_merkle_root(new_root);
 
-    start_cheat_caller_address(offsetter_address, john_address);
-    contract.claim(amount4, timestamp4, id_4, proof4);
-    assert!(contract.check_claimed(john_address, timestamp4, amount4, id_4));
-    assert!(!contract.check_claimed(john_address, timestamp3, amount3, id_3));
+    //start_cheat_caller_address(offsetter_address, john_address);
+    assert!(contract.confirm_for_merkle_tree(john_address, amount4, timestamp4, id_4, proof4));
 }

--- a/tests/test_merkle_tree.cairo
+++ b/tests/test_merkle_tree.cairo
@@ -66,31 +66,8 @@ fn test_bob_claims_single_allocation() {
     start_cheat_caller_address(offsetter_address, bob_address);
     assert_eq!(contract.get_merkle_root(), root);
 
-    //start_cheat_caller_address(offsetter_address, bob_address);
     assert!(contract.confirm_for_merkle_tree(bob_address, amount, timestamp, id, proof));
 }
-
-///Keep this test for the confirm_offset tests.
-//#[test]
-//#[should_panic(expected: 'Already claimed')]
-//fn test_bob_claims_twice() {
-//    /// Test that trying to confirm_for_merkle_tree the same allocation twice results in a panic.
-//    let owner_address = contract_address_const::<'OWNER'>();
-//    let (root, bob_address, amount, timestamp, id, proof) = get_bob_first_wave_allocation();
-//    let project_address = default_setup_and_deploy();
-//    let offsetter_address = deploy_offsetter(project_address);
-//    let contract = IOffsetHandlerDispatcher { contract_address: offsetter_address };
-//
-//    start_cheat_caller_address(offsetter_address, owner_address);
-//    contract.set_merkle_root(root);
-//    assert!(!contract.check_claimed(bob_address, timestamp, amount, id));
-//
-//    //start_cheat_caller_address(offsetter_address, bob_address);
-//    contract.confirm_for_merkle_tree(bob_address, amount, timestamp, id, proof.clone());
-//    assert!(contract.check_claimed(bob_address, timestamp, amount, id));
-//
-//    contract.confirm_for_merkle_tree(bob_address, amount, timestamp, id, proof);
-//}
 
 #[test]
 #[should_panic(expected: 'Invalid proof')]
@@ -106,7 +83,6 @@ fn test_claim_with_invalid_address() {
     let invalid_address = contract_address_const::<'DUMMY'>();
     assert!(!contract.check_claimed(invalid_address, timestamp, amount, id));
 
-    //start_cheat_caller_address(offsetter_address, invalid_address);
     assert!(!contract.confirm_for_merkle_tree(invalid_address, amount, timestamp, id, proof));
 }
 
@@ -124,7 +100,6 @@ fn test_claim_with_invalid_amount() {
     let invalid_amount = 0;
     assert!(!contract.check_claimed(bob_address, timestamp, invalid_amount, id));
 
-    //start_cheat_caller_address(offsetter_address, bob_address);
     assert!(!contract.confirm_for_merkle_tree(bob_address, invalid_amount, timestamp, id, proof));
 }
 
@@ -142,7 +117,6 @@ fn test_claim_with_invalid_timestamp() {
     let invalid_timestamp = 0;
     assert!(!contract.check_claimed(bob_address, invalid_timestamp, amount, id));
 
-    //start_cheat_caller_address(offsetter_address, bob_address);
     assert!(!contract.confirm_for_merkle_tree(bob_address, amount, invalid_timestamp, id, proof));
 }
 
@@ -160,34 +134,8 @@ fn test_claim_with_invalid_proof() {
     let invalid_proof: Array<felt252> = array![0x123, 0x1];
     assert!(!contract.check_claimed(bob_address, timestamp, amount, id));
 
-    //start_cheat_caller_address(offsetter_address, bob_address);
     assert!(!contract.confirm_for_merkle_tree(bob_address, amount, timestamp, id, invalid_proof));
 }
-
-///Keep this test for the confirm_offset tests.
-//#[test]
-//fn test_event_emission_on_claim() {
-//    let (root, bob_address, amount, timestamp, id, proof) = get_bob_first_wave_allocation();
-//    let owner_address = contract_address_const::<'OWNER'>();
-//    let project_address = default_setup_and_deploy();
-//    let offsetter_address = deploy_offsetter(project_address);
-//    let contract = IOffsetHandlerDispatcher { contract_address: offsetter_address };
-//
-//    start_cheat_caller_address(offsetter_address, owner_address);
-//    contract.set_merkle_root(root);
-//    assert!(!contract.check_claimed(bob_address, timestamp, amount, id));
-//
-//    let mut spy = spy_events();
-//    //start_cheat_caller_address(offsetter_address, bob_address);
-//    contract.confirm_for_merkle_tree(bob_address, amount, timestamp, id, proof);
-//
-//    let expected_event = OffsetComponent::Event::AllocationClaimed(
-//        OffsetComponent::AllocationClaimed { claimee: bob_address, amount, timestamp, id }
-//    );
-//    spy.assert_emitted(@array![(offsetter_address, expected_event)]);
-//
-//    assert!(contract.check_claimed(bob_address, timestamp, amount, id));
-//}
 
 #[test]
 fn test_claim_after_root_update() {
@@ -206,7 +154,6 @@ fn test_claim_after_root_update() {
     contract.set_merkle_root(new_root);
     assert!(!contract.check_claimed(bob_address, timestamp, amount, id));
 
-    //start_cheat_caller_address(offsetter_address, bob_address);
     assert!(contract.confirm_for_merkle_tree(bob_address, amount, timestamp, id, new_proof));
 }
 
@@ -223,7 +170,6 @@ fn test_alice_claims_in_second_wave() {
     contract.set_merkle_root(root);
     assert!(!contract.check_claimed(bob_address, timestamp, amount, id));
 
-    //start_cheat_caller_address(offsetter_address, bob_address);
     assert!(contract.confirm_for_merkle_tree(bob_address, amount, timestamp, id, proof));
 
     let (new_root, alice_address, amount, timestamp, id, proof) =
@@ -232,7 +178,6 @@ fn test_alice_claims_in_second_wave() {
     contract.set_merkle_root(new_root);
     assert!(!contract.check_claimed(alice_address, timestamp, amount, id));
 
-    //start_cheat_caller_address(offsetter_address, alice_address);
     assert!(contract.confirm_for_merkle_tree(alice_address, amount, timestamp, id, proof));
 }
 
@@ -273,13 +218,11 @@ fn test_john_claims_multiple_allocations() {
     assert!(!contract.check_claimed(john_address, timestamp2, amount2, id_2));
     assert!(!contract.check_claimed(john_address, timestamp3, amount3, id_3));
 
-    //start_cheat_caller_address(offsetter_address, john_address);
     assert!(contract.confirm_for_merkle_tree(john_address, amount1, timestamp1, id_1, proof1));
     assert!(contract.confirm_for_merkle_tree(john_address, amount2, timestamp2, id_2, proof2));
 
     start_cheat_caller_address(offsetter_address, owner_address);
     contract.set_merkle_root(new_root);
 
-    //start_cheat_caller_address(offsetter_address, john_address);
     assert!(contract.confirm_for_merkle_tree(john_address, amount4, timestamp4, id_4, proof4));
 }

--- a/tests/test_offsetter.cairo
+++ b/tests/test_offsetter.cairo
@@ -589,7 +589,6 @@ fn test_confirm_offset() {
     assert!(offsetter.check_claimed(bob_address, timestamp, amount, id));
 
     assert!(offsetter.get_retirement(token_id, bob_address) == new_retirement)
-
 }
 
 #[test]
@@ -737,20 +736,29 @@ fn test_events_emission_on_claim_confirmation() {
     let mut spy = spy_events();
     offsetter.confirm_offset(amount, timestamp, id, proof);
 
-
     let first_expected_event = OffsetComponent::Event::Retired(
-        OffsetComponent::Retired { from: bob_address, project : project_address,
-             token_id : token_id, old_amount : current_retirement, new_amount : new_retirement }
+        OffsetComponent::Retired {
+            from: bob_address,
+            project: project_address,
+            token_id: token_id,
+            old_amount: current_retirement,
+            new_amount: new_retirement
+        }
     );
 
     let second_expected_event = OffsetComponent::Event::AllocationClaimed(
         OffsetComponent::AllocationClaimed { claimee: bob_address, amount, timestamp, id }
     );
-    
-    spy.assert_emitted(@array![(offsetter_address, first_expected_event), (offsetter_address, second_expected_event)]);
+
+    spy
+        .assert_emitted(
+            @array![
+                (offsetter_address, first_expected_event),
+                (offsetter_address, second_expected_event)
+            ]
+        );
 
     assert!(offsetter.check_claimed(bob_address, timestamp, amount, id));
-
 }
 
 
@@ -823,7 +831,6 @@ fn test_claim_confirmation_with_invalid_amount() {
     let invalid_amount = 0;
 
     offsetter.confirm_offset(invalid_amount, timestamp, id, proof);
-
 }
 
 #[test]
@@ -900,11 +907,12 @@ fn test_alice_confirms_in_second_wawe() {
     assert!(offsetter.check_claimed(bob_address, timestamp, amount, id));
 
     assert!(offsetter.get_retirement(token_id, bob_address) == new_retirement);
-    
+
     stop_cheat_caller_address(erc20_address);
     stop_cheat_caller_address(project_address);
 
-    let (new_root, alice_address, amount, timestamp, id, proof) = get_alice_second_wave_allocation();
+    let (new_root, alice_address, amount, timestamp, id, proof) =
+        get_alice_second_wave_allocation();
 
     start_cheat_caller_address(offsetter_address, alice_address);
     start_cheat_caller_address(project_address, owner_address);
@@ -921,7 +929,6 @@ fn test_alice_confirms_in_second_wawe() {
     let initial_balance = project.balance_of(alice_address, token_id);
 
     let amount_to_offset: u256 = amount.into();
-
 
     start_cheat_caller_address(offsetter_address, alice_address);
     start_cheat_caller_address(project_address, offsetter_address);
@@ -1033,10 +1040,9 @@ fn test_john_confirms_multiple_allocations() {
     project.set_approval_for_all(offsetter_address, true);
     stop_cheat_caller_address(erc20_address);
 
-
     start_cheat_caller_address(offsetter_address, john_address);
     start_cheat_caller_address(project_address, offsetter_address);
-    
+
     offsetter.retire_carbon_credits(token_id, amount1_to_offset);
     assert!(!offsetter.check_claimed(john_address, timestamp1, amount1, id_1));
     offsetter.confirm_offset(amount1, timestamp1, id_1, proof1);
@@ -1047,7 +1053,6 @@ fn test_john_confirms_multiple_allocations() {
 
     assert!(offsetter.check_claimed(john_address, timestamp1, amount1, id_1));
     assert!(offsetter.check_claimed(john_address, timestamp2, amount2, id_2));
-
 
     start_cheat_caller_address(offsetter_address, owner_address);
     offsetter.set_merkle_root(new_root);
@@ -1060,5 +1065,4 @@ fn test_john_confirms_multiple_allocations() {
     offsetter.confirm_offset(amount4, timestamp4, id_4, proof4);
 
     assert!(offsetter.check_claimed(john_address, timestamp4, amount4, id_4));
-
 }

--- a/tests/test_offsetter.cairo
+++ b/tests/test_offsetter.cairo
@@ -834,7 +834,7 @@ fn test_claim_confirmation_with_invalid_amount() {
 }
 
 #[test]
-fn test_alice_confirms_in_second_wawe() {
+fn test_alice_confirms_in_second_wave() {
     /// Test that Bob can confirm his offset from the first wave and Alice can confirm her offset from the second wave.
     let owner_address = contract_address_const::<'OWNER'>();
     let project_address = default_setup_and_deploy();


### PR DESCRIPTION
On Ainur's advice, I modified the claim function and split it into two parts: the first is confirm_for_merkle_tree, which confirms the offset on the Merkle tree side by validating the proof provided by the user; the second is confirm_offset, which handles business logic checks (e.g., ensuring the claim hasn't already been made, verifying that there is sufficient pending retirement, etc.), calls confirm_for_merkle_tree for Merkle tree checks, and performs the offset action with _offset_carbon_credit.

Consequently, the tests for the claim function in test_merkle_tree.cairo have been converted to tests for the confirm_for_merkle_tree function.

I added tests for the confirm_claim function in test_offseter.cairo.

I also added two getters, get_allocation_id and get_retirement, in the offsetter code as they were needed for my tests.

Remarks:

I considered checking the vintage status in the confirm_offset function, but since this is already done in retire_carbon_credits, I concluded it was unnecessary.

Since the claim_for_merkle_tree function is internal to confirm_offset, we needed to determine how to call it. It is not callable by the user (or anyone other than the contract itself). Therefore, I added a from parameter representing the claimer's address to avoid issues related to calling the function, ensuring it is only invoked by the contract.

We realized when attempting to call _offset_carbon_credit that there is no mapping from allocation_id to allocation. This will need to be addressed in a future PR: adding the token_id field to the allocation struct (which will involve modifying aspects of the Merkle tree, especially the intermediate_hash in the confirm_for_merkle_tree method).

For now, in this PR, we assume that only vintages with token_id = 1 are offset, which is why we set self._offset_carbon_credit(claimee, 1, amount.into()) in confirm_offset.

-> In the confirm_offset tests, we perform the deposit and the entire process with token_id set to 1.

In confirm_offset, in the [Mark as claimed] section, would it be better to use a getter for the allocation instead of recreating one (with the exact same fields) each time?