### PR TITLE
🧱 lib tag added

### DIFF
--- a/Scarb.toml
+++ b/Scarb.toml
@@ -19,3 +19,5 @@ test = "snforge test --max-n-steps 30000000"
 [[target.starknet-contract]]
 sierra = true
 casm = true
+
+[lib]


### PR DESCRIPTION
Allow the use of Cpv3 as a lib for external use (i.e carbon locker)